### PR TITLE
Use u32 to represent variant tags.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -76,7 +76,8 @@ impl<'a, R: Reader+Buffer> Decoder<IoError> for DecoderReader<'a, R> {
         }
     fn read_enum_variant<T, F>(&mut self, names: &[&str], mut f: F) -> IoResult<T> where
         F: FnMut(&mut DecoderReader<'a, R>, uint) -> IoResult<T> {
-            let id = try!(self.read_uint());
+            let id = try!(self.read_u32());
+            let id = id as uint;
             if id >= names.len() {
                 Err(IoError {
                     kind: OtherIoError,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,6 @@
 use std::io::{Writer, IoError, IoResult};
 use rustc_serialize::Encoder;
+use std::num::Int;
 
 type EwResult = IoResult<()>;
 
@@ -70,7 +71,11 @@ impl<'a, W: Writer> Encoder<IoError> for EncoderWriter<'a, W> {
                             _: uint,
                             f: F) -> EwResult where
         F: FnOnce(&mut EncoderWriter<'a, W>) -> EwResult {
-            try!(self.emit_uint(v_id));
+            let max_u32: u32 = Int::max_value();
+            if v_id > (max_u32 as uint) {
+                panic!("Variant tag doesn't fit in a u32")
+            }
+            try!(self.emit_u32(v_id as u32));
             f(self)
         }
     fn emit_enum_variant_arg<F>(&mut self, _: uint, f: F) -> EwResult where


### PR DESCRIPTION
This makes it possible to exchange binary serialized structures between
different architectures, and reduces bandwidth.  I doubt it's even
possible to have more than 4 billions variants anyway :).