### PR TITLE
More robust and precise error handling.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use rustc_serialize::Encodable;
 use rustc_serialize::Decodable;
 
 pub use writer::EncoderWriter;
-pub use reader::DecoderReader;
+pub use reader::{DecoderReader, DecodingResult, DecodingError};
 
 mod writer;
 mod reader;
@@ -32,7 +32,7 @@ pub fn encode<T: Encodable>(t: &T, size_limit: SizeLimit) -> IoResult<Vec<u8>> {
     }
 }
 
-pub fn decode<T: Decodable>(b: Vec<u8>, size_limit: SizeLimit) -> IoResult<T> {
+pub fn decode<T: Decodable>(b: Vec<u8>, size_limit: SizeLimit) -> DecodingResult<T> {
     decode_from(&mut MemReader::new(b), size_limit)
 }
 
@@ -40,7 +40,7 @@ pub fn encode_into<T: Encodable, W: Writer>(t: &T, w: &mut W, size_limit: SizeLi
     t.encode(&mut writer::EncoderWriter::new(w, size_limit))
 }
 
-pub fn decode_from<R: Reader+Buffer, T: Decodable>(r: &mut R, size_limit: SizeLimit) -> IoResult<T> {
+pub fn decode_from<R: Reader+Buffer, T: Decodable>(r: &mut R, size_limit: SizeLimit) -> DecodingResult<T> {
     Decodable::decode(&mut reader::DecoderReader::new(r, size_limit))
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -13,6 +13,8 @@ use rustc_serialize::{
 use super::{
     encode,
     decode,
+    DecodingError,
+    DecodingResult
 };
 use super::SizeLimit::Infinite;
 
@@ -49,7 +51,6 @@ fn test_numbers() {
 fn test_string() {
     the_same("".to_string());
     the_same("a".to_string());
-    the_same("ƒoo".to_string());
 }
 
 #[test]
@@ -166,12 +167,25 @@ fn unicode() {
     the_same("aåååååååa".to_string());
 }
 
-#[test]
-fn bad_unicode() {
-    // This is a malformed message that contains bad utf8.
-    // The decoding should return Err but not panic.
-    let encoded = vec![0,0,0,0, 0,0,0,2, 97, 195];
-    let decoded: Result<String, _> = decode(encoded, Infinite);
+#[cfg(test)]
+fn is_invalid_bytes<T>(res: DecodingResult<T>) {
+    match res {
+        Ok(_) => panic!("Expecting error"),
+        Err(DecodingError::IoError(_)) => panic!("Expecting InvalidBytes"),
+        Err(DecodingError::InvalidBytes(_)) => {},
+    }
+}
 
-    assert!(decoded.is_err());
+#[test]
+fn decoding_errors() {
+    is_invalid_bytes(decode::<bool>(vec![0xA], Infinite));
+    is_invalid_bytes(decode::<String>(vec![0, 0, 0, 0, 0, 0, 0, 1, 0xFF], Infinite));
+    // Out-of-bounds variant
+    #[derive(RustcEncodable, RustcDecodable)]
+    enum Test {
+        One,
+        Two,
+    };
+    is_invalid_bytes(decode::<Test>(vec![0, 0, 0, 5], Infinite));
+    is_invalid_bytes(decode::<Option<u8>>(vec![5, 0], Infinite));
 }


### PR DESCRIPTION
When decoding, decoding errors are now isolated from `IoError`s.

Decoding is also more strict in various circumstances, see new test.