### PR TITLE
Don't require BufRead, only Read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ pub use writer::{EncoderWriter, EncodingResult, EncodingError};
 pub use reader::{DecoderReader, DecodingResult, DecodingError};
 use writer::SizeChecker;
 
-use std::io::{Write, BufRead};
+use std::io::{Write, Read};
 
 mod writer;
 mod reader;
@@ -134,7 +134,7 @@ pub fn encode_into<T: Encodable, W: Write>(t: &T, w: &mut W, size_limit: SizeLim
 /// If this returns an `DecodingError`, assume that the buffer that you passed
 /// in is in an invalid state, as the error could be returned during any point
 /// in the reading.
-pub fn decode_from<R: BufRead, T: Decodable>(r: &mut R, size_limit: SizeLimit) ->
+pub fn decode_from<R: Read, T: Decodable>(r: &mut R, size_limit: SizeLimit) ->
 DecodingResult<T> {
     Decodable::decode(&mut reader::DecoderReader::new(r, size_limit))
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,4 @@
-use std::io::{BufRead, Read};
+use std::io::Read;
 use std::io::Error as IoError;
 use std::io::Result as IoResult;
 use std::num::{cast, NumCast};
@@ -110,7 +110,7 @@ pub struct DecoderReader<'a, R: 'a> {
     read: u64
 }
 
-impl<'a, R: BufRead> DecoderReader<'a, R> {
+impl<'a, R: Read> DecoderReader<'a, R> {
     pub fn new(r: &'a mut R, size_limit: SizeLimit) -> DecoderReader<'a, R> {
         DecoderReader {
             reader: r,
@@ -137,7 +137,7 @@ impl <'a, A> DecoderReader<'a, A> {
     }
 }
 
-impl<'a, R: BufRead> Decoder for DecoderReader<'a, R> {
+impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
     type Error = DecodingError;
 
     fn read_nil(&mut self) -> DecodingResult<()> {


### PR DESCRIPTION
While BufRead is preferable to avoid dog-slow performance, requiring
when no methods are called is also problematic, especially for wrappers
around Read that shouldn't necessarily need to know they're wrapping
BufRead.