### PR TITLE
bump byteorder dependency to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ description = "A binary serialization / deserialization strategy and implementat
 
 [dependencies]
 rustc-serialize = "0.3.*"
-byteorder = "0.2.9"
+byteorder = "0.3.1"


### PR DESCRIPTION
byteorder 0.2.9 no longer builds on rustc nightly; bumping this dependency to 0.3.1 fixes this issue