### PR TITLE
Fix for upstream rustc changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ fn main() {
     // 8 bytes for the length of the vector, 4 bytes per float.
     assert_eq!(encoded.len(), 8 + 4 * 4);
 
-    let decoded: World = bincode::decode(&encoded[]).unwrap();
+    let decoded: World = bincode::decode(&encoded[..]).unwrap();
 
     assert!(world == decoded);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ mod refbox;
 ///!     let limit = bincode::SizeLimit::Bounded(20);
 ///!
 ///!     let encoded: Vec<u8>        = bincode::encode(&target, limit).unwrap();
-///!     let decoded: Option<String> = bincode::decode(&encoded[]).unwrap();
+///!     let decoded: Option<String> = bincode::decode(&encoded[..]).unwrap();
 ///!     assert_eq!(target, decoded);
 ///! }
 ///! ```

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -123,7 +123,8 @@ impl<'a, R: Read> DecoderReader<'a, R> {
 impl <'a, A> DecoderReader<'a, A> {
     fn read_bytes<I>(&mut self, count: I) -> Result<(), DecodingError>
     where I: NumCast {
-        self.read += cast(count).unwrap();
+        let count: u64 = cast(count).unwrap();
+        self.read += count;
         match self.size_limit {
             SizeLimit::Infinite => Ok(()),
             SizeLimit::Bounded(x) if self.read <= x => Ok(()),


### PR DESCRIPTION
Fixes new rustc 2015-03-30 issue:

````
src/reader.rs:126:22: 126:42 error: the type of this value must be known in this context
src/reader.rs:126         self.read += cast(count).unwrap();
````