### PR TITLE
refbox: add Debug impl

### DIFF
--- a/src/refbox.rs
+++ b/src/refbox.rs
@@ -1,5 +1,6 @@
 use std::boxed::Box;
 use std::ops::Deref;
+use std::fmt;
 
 use rustc_serialize::{Encodable, Encoder};
 use rustc_serialize::{Decodable, Decoder};
@@ -149,3 +150,8 @@ impl <'a, T> Deref for RefBox<'a, T> {
     }
 }
 
+impl <'a, T: fmt::Debug> fmt::Debug for RefBox<'a, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(fmt, "RefBox({:?})", *self)
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -269,7 +269,7 @@ fn test_refbox() {
     large_map.insert(1, 2);
 
 
-    #[derive(RustcEncodable, RustcDecodable)]
+    #[derive(RustcEncodable, RustcDecodable, Debug)]
     enum Message<'a> {
         M1(RefBox<'a, Vec<u32>>),
         M2(RefBox<'a, HashMap<u32, u32>>)


### PR DESCRIPTION
Allows `#[derive(Debug)]` to work with things containing RefBox.

Not sure adding impls like this is sustainable.

I used to be able to do
```
impl<'a> fmt::Debug for bincode::RefBox<'a, MyLocalType> {
    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
        write!(fmt, "RefBox({:?})", *self)
    }
}
```
Locally, but recent rust has forbidden this.
