### PR TITLE
SliceBox: allow Deref into &[T]

### DIFF
--- a/src/refbox.rs
+++ b/src/refbox.rs
@@ -322,3 +322,14 @@ impl <'a, T> Deref for RefBox<'a, T> {
         }
     }
 }
+
+impl <'a, T> Deref for SliceBox<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        match &self.inner {
+            &RefBoxInner::Ref(ref t) => t,
+            &RefBoxInner::Box(ref b) => b.deref()
+        }
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -311,6 +311,10 @@ fn test_slicebox() {
     let slice = [1u32, 2, 3 ,4, 5];
     let encoded = encode(&SliceBox::new(&slice), Infinite).unwrap();
     let decoded: SliceBox<'static, u32> = decode(&encoded[..]).unwrap();
+    {
+        let sb: &[u32] = &decoded;
+        assert!(slice == sb);
+    }
     let vecx: Vec<u32> = decoded.take();
     assert!(slice == &vecx[..]);
 }


### PR DESCRIPTION
Allows more convenient use of SliceBox where one doesn't care whether
it represents a Vec<T> or &[T] and can handle using a &[T].