### PR TITLE
Temporary serde dependency fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A binary serialization / deserialization strategy and implementat
 rustc-serialize = "0.3.*"
 byteorder = "0.4.*"
 num = "^0.1"
-serde = "^0.6"
+serde = "0.6"
 
 [dev-dependencies]
 serde_macros = "*"


### PR DESCRIPTION
As stated in #55 #56 builds are failing right now because of an update of serde.