### PR TITLE
Respect size limits in read_seq and read_map.

### DIFF
--- a/src/rustc_serialize/reader.rs
+++ b/src/rustc_serialize/reader.rs
@@ -347,8 +347,15 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         let len = try!(self.read_usize());
         match self.size_limit {
             SizeLimit::Infinite => (),
-            SizeLimit::Bounded(x) if self.read.saturating_add(len as u64) <= x => (),
-            SizeLimit::Bounded(_) => return Err(DecodingError::SizeLimit),
+            SizeLimit::Bounded(x) => {
+                let overflow = match self.read.checked_add(len as u64) {
+                    Some(y) => y > x,
+                    None => true,
+                };
+                if overflow {
+                    return Err(DecodingError::SizeLimit);
+                }
+            },
         };
         f(self, len)
     }
@@ -363,8 +370,15 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         let len = try!(self.read_usize());
         match self.size_limit {
             SizeLimit::Infinite => (),
-            SizeLimit::Bounded(x) if self.read.saturating_add(len as u64) <= x => (),
-            SizeLimit::Bounded(_) => return Err(DecodingError::SizeLimit),
+            SizeLimit::Bounded(x) => {
+                let overflow = match self.read.checked_add(len as u64) {
+                    Some(y) => y > x,
+                    None => true,
+                };
+                if overflow {
+                    return Err(DecodingError::SizeLimit);
+                }
+            },
         };
         f(self, len)
     }

--- a/src/rustc_serialize/reader.rs
+++ b/src/rustc_serialize/reader.rs
@@ -129,7 +129,10 @@ impl<'a, R: Read> DecoderReader<'a, R> {
 
 impl <'a, A> DecoderReader<'a, A> {
     fn read_bytes(&mut self, count: u64) -> Result<(), DecodingError> {
-        self.read += count;
+        self.read = match self.read.checked_add(count) {
+            Some(read) => read,
+            None => return Err(DecodingError::SizeLimit),
+        };
         match self.size_limit {
             SizeLimit::Infinite => Ok(()),
             SizeLimit::Bounded(x) if self.read <= x => Ok(()),
@@ -342,6 +345,11 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         where F: FnOnce(&mut DecoderReader<'a, R>, usize) -> DecodingResult<T>
     {
         let len = try!(self.read_usize());
+        match self.size_limit {
+            SizeLimit::Infinite => (),
+            SizeLimit::Bounded(x) if self.read.saturating_add(len as u64) <= x => (),
+            SizeLimit::Bounded(_) => return Err(DecodingError::SizeLimit),
+        };
         f(self, len)
     }
     fn read_seq_elt<T, F>(&mut self, _: usize, f: F) -> DecodingResult<T>
@@ -353,6 +361,11 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         where F: FnOnce(&mut DecoderReader<'a, R>, usize) -> DecodingResult<T>
     {
         let len = try!(self.read_usize());
+        match self.size_limit {
+            SizeLimit::Infinite => (),
+            SizeLimit::Bounded(x) if self.read.saturating_add(len as u64) <= x => (),
+            SizeLimit::Bounded(_) => return Err(DecodingError::SizeLimit),
+        };
         f(self, len)
     }
     fn read_map_elt_key<T, F>(&mut self, _: usize, f: F) -> DecodingResult<T>


### PR DESCRIPTION
It's possible to cause the bincode rustc_serialise decoder to panic with OOM even if a size limit is set. This PR makes the `read_seq` and `read_map` decoder methods check that the number of elements about to be read is not greater than the number of bytes remaining before we hit the limit. This is not a perfect solution as it sort-of assumes that all types have size 1. For instance, if the size limit is 1KB it should still be allowable to decode a `Vec` of a million `()`s whereas it shouldn't be allowable to decode a `Vec` of 500 `u32`s. With this fix, neither of these situations are handled correctly. However I don't see a solution to this, and having this fix is better than not having it.

This PR also uses `checked_add` in `read_bytes` to so that people can't use malicious data to cause an overflow exception.