### PR TITLE
Revert "Respect size limits in read_seq and read_map."

### DIFF
--- a/src/rustc_serialize/reader.rs
+++ b/src/rustc_serialize/reader.rs
@@ -345,18 +345,6 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         where F: FnOnce(&mut DecoderReader<'a, R>, usize) -> DecodingResult<T>
     {
         let len = try!(self.read_usize());
-        match self.size_limit {
-            SizeLimit::Infinite => (),
-            SizeLimit::Bounded(x) => {
-                let overflow = match self.read.checked_add(len as u64) {
-                    Some(y) => y > x,
-                    None => true,
-                };
-                if overflow {
-                    return Err(DecodingError::SizeLimit);
-                }
-            },
-        };
         f(self, len)
     }
     fn read_seq_elt<T, F>(&mut self, _: usize, f: F) -> DecodingResult<T>
@@ -368,18 +356,6 @@ impl<'a, R: Read> Decoder for DecoderReader<'a, R> {
         where F: FnOnce(&mut DecoderReader<'a, R>, usize) -> DecodingResult<T>
     {
         let len = try!(self.read_usize());
-        match self.size_limit {
-            SizeLimit::Infinite => (),
-            SizeLimit::Bounded(x) => {
-                let overflow = match self.read.checked_add(len as u64) {
-                    Some(y) => y > x,
-                    None => true,
-                };
-                if overflow {
-                    return Err(DecodingError::SizeLimit);
-                }
-            },
-        };
         f(self, len)
     }
     fn read_map_elt_key<T, F>(&mut self, _: usize, f: F) -> DecodingResult<T>


### PR DESCRIPTION
This reverts commit 45fcb1cebc4247a47d6d88f9e6057315237e4c03.