### PR TITLE
Add cargo features for rustc-serialize and serde

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ script:
     - multirust default $CHANNEL
     - cargo build
     - if [ $CHANNEL = 'nightly' ] ; then cargo test ; fi
+    - cargo build --no-default-features --features "rustc-serialize"
+    - cargo build --no-default-features --features "serde"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ install:
 script:
     - multirust default $CHANNEL
     - cargo build
-    - if [ $CHANNEL = 'nightly' ] ; then cargo test ; fi
     - cargo build --no-default-features --features "rustc-serialize"
     - cargo build --no-default-features --features "serde"
+    - if [ $CHANNEL = 'nightly' ] ; then cargo test ; fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,13 @@ license = "MIT"
 description = "A binary serialization / deserialization strategy and implementation."
 
 [dependencies]
-rustc-serialize = "0.3.*"
+rustc-serialize = { version = "0.3.*", optional = true }
 byteorder = "0.5.*"
 num = "0.1.*"
-serde = "0.7.*"
+serde = { version = "0.7.*", optional = true }
 
 [dev-dependencies]
 serde_macros = "0.7.*"
+
+[features]
+default = ["rustc-serialize", "serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,16 +37,20 @@
 
 #![doc(html_logo_url = "./icon.png")]
 
+#[cfg(feature = "rustc-serialize")]
 extern crate rustc_serialize as rustc_serialize_crate;
 extern crate byteorder;
 extern crate num;
+#[cfg(feature = "serde")]
 extern crate serde as serde_crate;
 
 
 pub use refbox::{RefBox, StrBox, SliceBox};
 
 mod refbox;
+#[cfg(feature = "rustc-serialize")]
 pub mod rustc_serialize;
+#[cfg(feature = "serde")]
 pub mod serde;
 
 /// A limit on the amount of bytes that can be read or written.

--- a/src/refbox.rs
+++ b/src/refbox.rs
@@ -1,8 +1,10 @@
 use std::boxed::Box;
 use std::ops::Deref;
 
+#[cfg(feature = "rustc-serialize")]
 use rustc_serialize_crate::{Encodable, Encoder, Decodable, Decoder};
 
+#[cfg(feature = "serde")]
 use serde_crate as serde;
 
 /// A struct for encoding nested reference types.
@@ -139,13 +141,14 @@ impl <T> RefBox<'static, T>  {
     }
 }
 
-
+#[cfg(feature = "rustc-serialize")]
 impl <'a, T: Encodable> Encodable for RefBox<'a, T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         self.inner.encode(s)
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl <T: Decodable> Decodable for RefBox<'static, T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<RefBox<'static, T>, D::Error> {
         let inner = try!(Decodable::decode(d));
@@ -153,6 +156,7 @@ impl <T: Decodable> Decodable for RefBox<'static, T> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a, T> serde::Serialize for RefBox<'a, T>
     where T: serde::Serialize,
 {
@@ -163,6 +167,7 @@ impl<'a, T> serde::Serialize for RefBox<'a, T>
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T: serde::Deserialize> serde::Deserialize for RefBox<'static, T> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: serde::Deserializer
@@ -234,12 +239,14 @@ impl StrBox<'static>  {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl <'a> Encodable for StrBox<'a> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         self.inner.encode(s)
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl Decodable for StrBox<'static> {
     fn decode<D: Decoder>(d: &mut D) -> Result<StrBox<'static>, D::Error> {
         let inner: RefBoxInner<'static, str, String> = try!(Decodable::decode(d));
@@ -247,6 +254,7 @@ impl Decodable for StrBox<'static> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a> serde::Serialize for StrBox<'a> {
     fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
         where S: serde::Serializer
@@ -255,6 +263,7 @@ impl<'a> serde::Serialize for StrBox<'a> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl serde::Deserialize for StrBox<'static> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: serde::Deserializer
@@ -321,12 +330,14 @@ impl <T> SliceBox<'static, T>  {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl <'a, T: Encodable> Encodable for SliceBox<'a, T> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         self.inner.encode(s)
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl <T: Decodable> Decodable for SliceBox<'static, T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<SliceBox<'static, T>, D::Error> {
         let inner: RefBoxInner<'static, [T], Vec<T>> = try!(Decodable::decode(d));
@@ -334,6 +345,7 @@ impl <T: Decodable> Decodable for SliceBox<'static, T> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a, T> serde::Serialize for SliceBox<'a, T>
     where T: serde::Serialize,
 {
@@ -344,6 +356,7 @@ impl<'a, T> serde::Serialize for SliceBox<'a, T>
     }
 }
 
+#[cfg(feature = "serde")]
 impl<T: serde::Deserialize> serde::Deserialize for SliceBox<'static, T> {
     fn deserialize<D>(deserializer: &mut D) -> Result<Self, D::Error>
         where D: serde::Deserializer
@@ -353,6 +366,7 @@ impl<T: serde::Deserialize> serde::Deserialize for SliceBox<'static, T> {
     }
 }
 
+#[cfg(feature = "rustc-serialize")]
 impl <'a, A: Encodable + ?Sized, B: Encodable> Encodable for RefBoxInner<'a, A, B> {
     fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
         match self {
@@ -362,6 +376,7 @@ impl <'a, A: Encodable + ?Sized, B: Encodable> Encodable for RefBoxInner<'a, A, 
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a, A: ?Sized, B> serde::Serialize for RefBoxInner<'a, A, B>
     where A: serde::Serialize,
           B: serde::Serialize,
@@ -376,7 +391,7 @@ impl<'a, A: ?Sized, B> serde::Serialize for RefBoxInner<'a, A, B>
     }
 }
 
-
+#[cfg(feature = "rustc-serialize")]
 impl <A: ?Sized, B: Decodable> Decodable for RefBoxInner<'static, A, B> {
     fn decode<D: Decoder>(d: &mut D) -> Result<RefBoxInner<'static, A, B>, D::Error> {
         let decoded = try!(Decodable::decode(d));
@@ -384,6 +399,7 @@ impl <A: ?Sized, B: Decodable> Decodable for RefBoxInner<'static, A, B> {
     }
 }
 
+#[cfg(feature = "serde")]
 impl<A: ?Sized, B> serde::Deserialize for RefBoxInner<'static, A, B>
     where B: serde::Deserialize,
 {


### PR DESCRIPTION
So you are allowed to depend only on what you use.
Tests depend heavily on both of these crates, so they only run with default features on.
So did example binary, I did not modify it for simplicity and clarity.