### PR TITLE
Don't pull `rustc-serialize` from `num`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "A binary serialization / deserialization strategy and implementat
 [dependencies]
 rustc-serialize = { version = "0.3.*", optional = true }
 byteorder = "0.5.*"
-num = "0.1.*"
+num = { version = "0.1.*", default-features = false }
 serde = { version = "0.7.*", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
This is a follow-up to the previous PR. I have overlooked that the `num` crate pulls `rustc-serialize` unconditionally (and it isn't used by the way), so I disabled it.