### PR TITLE
Derive Deserialize only for Message<'static>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ num-traits = "0.1.32"
 serde = { version = "0.7.*", optional = true }
 
 [dev-dependencies]
-serde_macros = "0.7.*"
+serde_macros = "0.7.8"
 
 [features]
 default = ["rustc-serialize", "serde"]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -395,6 +395,7 @@ fn test_refbox_serialize() {
 
 
     #[derive(RustcEncodable, RustcDecodable, Serialize, Deserialize, Debug)]
+    #[serde(bound(deserialize="'a: 'static"))]
     enum Message<'a> {
         M1(RefBox<'a, Vec<u32>>),
         M2(RefBox<'a, HashMap<u32, u32>>)


### PR DESCRIPTION
This is an alternative fix for #77. It is lower risk than #79.