### PR TITLE
pub used InvalidEncoding in serde+rustc_serialize so it shows in `cargo doc`

### DIFF
--- a/src/rustc_serialize/mod.rs
+++ b/src/rustc_serialize/mod.rs
@@ -7,7 +7,7 @@ use std::io::{Write, Read};
 use ::SizeLimit;
 
 pub use self::writer::{SizeChecker, EncoderWriter, EncodingResult, EncodingError};
-pub use self::reader::{DecoderReader, DecodingResult, DecodingError};
+pub use self::reader::{DecoderReader, DecodingResult, DecodingError, InvalidEncoding};
 
 mod reader;
 mod writer;

--- a/src/rustc_serialize/reader.rs
+++ b/src/rustc_serialize/reader.rs
@@ -11,8 +11,8 @@ use ::SizeLimit;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct InvalidEncoding {
-    desc: &'static str,
-    detail: Option<String>,
+    pub desc: &'static str,
+    pub detail: Option<String>,
 }
 
 impl fmt::Display for InvalidEncoding {

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -9,6 +9,7 @@ pub use self::reader::{
     Deserializer,
     DeserializeResult,
     DeserializeError,
+    InvalidEncoding
 };
 
 pub use self::writer::{
@@ -120,4 +121,3 @@ pub fn deserialize<T>(bytes: &[u8]) -> DeserializeResult<T>
     let mut reader = bytes;
     deserialize_from(&mut reader, SizeLimit::Infinite)
 }
-

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -8,7 +8,6 @@ use byteorder::{BigEndian, ReadBytesExt};
 use num_traits;
 use serde_crate as serde;
 use serde_crate::de::value::ValueDeserializer;
-use serde_crate::de::Deserializer as SerdeDeserializer;
 
 use ::SizeLimit;
 

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -13,8 +13,8 @@ use ::SizeLimit;
 
 #[derive(Eq, PartialEq, Clone, Debug)]
 pub struct InvalidEncoding {
-    desc: &'static str,
-    detail: Option<String>,
+    pub desc: &'static str,
+    pub detail: Option<String>,
 }
 
 impl fmt::Display for InvalidEncoding {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 use std::collections::HashMap;
 use std::ops::Deref;
 
-use rustc_serialize::{Encoder, Decoder, Encodable, Decodable};
+use rustc_serialize::{Encodable, Decodable};
 
 use bincode::{RefBox, StrBox, SliceBox};
 


### PR DESCRIPTION
* Removed some 'unused import' warnings
* Made both fields of InvalidEncoding public so it can be used without Display or Debug traits (e.g. pattern matching)