### PR TITLE
Delegate emit_enum_struct_variant calls to emit_enum_variant

### DIFF
--- a/src/rustc_serialize/writer.rs
+++ b/src/rustc_serialize/writer.rs
@@ -176,14 +176,14 @@ impl<'a, W: Write> Encoder for EncoderWriter<'a, W> {
         f(self)
     }
     fn emit_enum_struct_variant<F>(&mut self,
-                                   _: &str,
-                                   _: usize,
-                                   _: usize,
+                                   v_name: &str,
+                                   v_id: usize,
+                                   len: usize,
                                    f: F)
                                    -> EncodingResult<()>
         where F: FnOnce(&mut EncoderWriter<'a, W>) -> EncodingResult<()>
     {
-        f(self)
+        self.emit_enum_variant(v_name, v_id, len, f)
     }
     fn emit_enum_struct_variant_field<F>(&mut self, _: &str, _: usize, f: F) -> EncodingResult<()>
         where F: FnOnce(&mut EncoderWriter<'a, W>) -> EncodingResult<()>

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -515,3 +515,51 @@ fn path_buf() {
     let decoded: PathBuf = bincode::serde::deserialize(&serde_encoded).unwrap();
     assert!(path.to_str() == decoded.to_str());
 }
+
+#[test]
+fn test_manual_enum_encoding() {
+    #[derive(PartialEq)]
+    enum Enumeration {
+        Variant1,
+        Variant2 { val: u64 }
+    }
+
+    impl Encodable for Enumeration {
+        fn encode<S: Encoder>(&self, s: &mut S) -> Result<(), S::Error> {
+            s.emit_enum("Enumeration", |s| {
+                match *self {
+                    Enumeration::Variant1 => {
+                        s.emit_enum_variant("Variant1", 0, 0, |_| Ok(()))
+                    },
+                    Enumeration::Variant2 { val } => {
+                        s.emit_enum_struct_variant("Variant2", 1, 1, |s| {
+                            s.emit_enum_struct_variant_field("val", 0, |s| s.emit_u64(val))
+                        })
+                    }
+                }
+            })
+        }
+    }
+
+    impl Decodable for Enumeration {
+        fn decode<D: Decoder>(s: &mut D) -> Result<Self, D::Error> {
+            s.read_enum("Enumeration", |s| {
+                s.read_enum_struct_variant(&["Variant1", "Variant2"], |s, num| {
+                    match num {
+                        0 => Ok(Enumeration::Variant1),
+                        1 => Ok(Enumeration::Variant2 { val: try!(s.read_u64()) }),
+                        _ => Err(s.error("Unknown enum variant"))
+                    }
+                })
+            })
+        }
+    }
+
+    let encoded = bincode::rustc_serialize::encode(&Enumeration::Variant1, Infinite).unwrap();
+    let decoded: Enumeration = decode(&encoded[..]).unwrap();
+    assert!(decoded == Enumeration::Variant1);
+
+    let encoded = bincode::rustc_serialize::encode(&Enumeration::Variant2 { val: 42 }, Infinite).unwrap();
+    let decoded: Enumeration = decode(&encoded[..]).unwrap();
+    assert!(decoded == Enumeration::Variant2 { val: 42 });
+}


### PR DESCRIPTION
[`read_enum_struct_variant`](https://github.com/TyOverby/bincode/blob/f06a4cfcb5b194e54d4997c200c75b88b6c3fba4/src/rustc_serialize/reader.rs#L279-L283) delegates calls to [`read_enum_variant`](https://github.com/TyOverby/bincode/blob/f06a4cfcb5b194e54d4997c200c75b88b6c3fba4/src/rustc_serialize/reader.rs#L260-L263) which expects `u32` prefix to encode a variant number. Previous implementation of [`emit_enum_struct_variant`](https://github.com/TyOverby/bincode/blob/f06a4cfcb5b194e54d4997c200c75b88b6c3fba4/src/rustc_serialize/writer.rs#L178-L187) doesn't emit it, making serialized data invalid.