### PR TITLE
More efficient serialize_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ version = "0.8.*"
 optional = true
 
 [dev-dependencies]
-serde_macros = "0.8.*"
+serde_derive = "0.8.*"
 
 [features]
 default = ["rustc-serialize", "serde"]

--- a/src/serde/writer.rs
+++ b/src/serde/writer.rs
@@ -163,11 +163,8 @@ impl<'a, W: Write> serde::Serializer for Serializer<'a, W> {
     }
 
     fn serialize_bytes(&mut self, v: &[u8]) -> SerializeResult<()> {
-        let mut state = try!(self.serialize_seq(Some(v.len())));
-        for c in v {
-            try!(self.serialize_seq_elt(&mut state, c));
-        }
-        self.serialize_seq_end(state)
+        try!(self.serialize_usize(v.len()));
+        self.writer.write_all(v).map_err(SerializeError::IoError)
     }
 
     fn serialize_none(&mut self) -> SerializeResult<()> {
@@ -440,11 +437,8 @@ impl serde::Serializer for SizeChecker {
     }
 
     fn serialize_bytes(&mut self, v: &[u8]) -> SerializeResult<()> {
-        let mut state = try!(self.serialize_seq(Some(v.len())));
-        for c in v {
-            try!(self.serialize_seq_elt(&mut state, c));
-        }
-        self.serialize_seq_end(state)
+        try!(self.add_value(0 as u64));
+        self.add_raw(v.len())
     }
 
     fn serialize_none(&mut self) -> SerializeResult<()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -519,6 +519,18 @@ fn path_buf() {
 }
 
 #[test]
+fn bytes() {
+    let data = b"abc\0123";
+    let b = bincode::rustc_serialize::encode(&data, Infinite).unwrap();
+    let s = bincode::serde::serialize(&data, Infinite).unwrap();
+    assert_eq!(b, s);
+
+    use serde::bytes::Bytes;
+    let s2 = bincode::serde::serialize(&Bytes::new(data), Infinite).unwrap();
+    assert_eq!(s, s2);
+}
+
+#[test]
 fn test_manual_enum_encoding() {
     #[derive(PartialEq)]
     enum Enumeration {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ use std::fmt::Debug;
 use std::collections::HashMap;
 use std::ops::Deref;
 
-use rustc_serialize::{Encodable, Decodable};
+use rustc_serialize::{Encodable, Encoder, Decodable, Decoder};
 
 use bincode::{RefBox, StrBox, SliceBox};
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,7 @@
-#![feature(plugin, custom_derive, custom_attribute)]
-#![plugin(serde_macros)]
+#![feature(proc_macro)]
+
+#[macro_use]
+extern crate serde_derive;
 
 extern crate bincode;
 extern crate rustc_serialize;


### PR DESCRIPTION
Reported in IRC: user blank_name2 tried serializing `HashMap<String, HashSet<Bytes>>` vs `HashMap<String, HashSet<&Path>>`, the `&Path` version was done in ~.6 seconds while the `&[u8]` one took a full 3 seconds more.

This PR resolves the difference between the two while keeping the same serialized form.