### PR TITLE
Fix unintentional breaking API change in `Serializer`/`Deserializer`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,15 @@ pub mod refbox;
 mod serde;
 
 pub mod endian_choice {
-    pub use super::serde::{serialize, serialize_into, deserialize, deserialize_from};
+    pub use super::serde::{Deserializer, Serializer, serialize, serialize_into, deserialize, deserialize_from};
 }
 
 use std::io::{Read, Write};
 
-pub use serde::{Deserializer, Serializer, ErrorKind, Error, Result, serialized_size, serialized_size_bounded};
+pub use serde::{ErrorKind, Error, Result, serialized_size, serialized_size_bounded};
+
+pub type Deserializer<W> = serde::Deserializer<W, byteorder::LittleEndian>;
+pub type Serializer<W> = serde::Serializer<W, byteorder::LittleEndian>;
 
 /// Deserializes a slice of bytes into an object.
 ///


### PR DESCRIPTION
While introducing selectable endianness in
https://github.com/TyOverby/bincode/pull/103 , the new type parameter
has been hidden from the public `serialize()`, `deserialize()` etc.
functions, and only made available through an alternate API entry point.
The same kind of encapsulation also needs to be performed for the public
`Serializer` and `Deserializer` types.