### PR TITLE
Make example work with serde

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,35 +1,24 @@
-/*
+#[macro_use]
+extern crate serde_derive;
 extern crate bincode;
-extern crate
 
-use bincode::SizeLimit;
-use bincode::rustc_serialize::{encode, decode};
+use bincode::{serialize, deserialize, SizeLimit};
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq)]
+#[derive(Serialize, Deserialize, Debug)]
 struct Entity {
     x: f32,
     y: f32,
 }
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq)]
-struct World {
-    entities: Vec<Entity>
-}
+#[derive(Serialize, Deserialize, Debug)]
+struct World(Vec<Entity>);
 
 fn main() {
-    let world = World {
-        entities: vec![Entity {x: 0.0, y: 4.0}, Entity {x: 10.0, y: 20.5}]
-    };
+    let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = encode(&world, SizeLimit::Infinite).unwrap();
+    let encoded: Vec<u8> = serialize(&world, SizeLimit::Infinite).unwrap();
+    println!("Encoded: {:?} ({} bytes)", encoded, encoded.len());
 
-    // 8 bytes for the length of the vector, 4 bytes per float.
-    assert_eq!(encoded.len(), 8 + 4 * 4);
-
-    let decoded: World = decode(&encoded[..]).unwrap();
-
-    assert!(world == decoded);
+    let decoded: World = deserialize(&encoded[..]).unwrap();
+    println!("Decoded: {:?}", decoded);
 }
- */
-
-fn main() {}

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -4,21 +4,24 @@ extern crate bincode;
 
 use bincode::{serialize, deserialize, SizeLimit};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq)]
 struct Entity {
     x: f32,
     y: f32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq)]
 struct World(Vec<Entity>);
 
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
     let encoded: Vec<u8> = serialize(&world, SizeLimit::Infinite).unwrap();
-    println!("Encoded: {:?} ({} bytes)", encoded, encoded.len());
+
+    // 8 bytes for the length of the vector, 4 bytes per float.
+    assert_eq!(encoded.len(), 8 + 4 * 4);
 
     let decoded: World = deserialize(&encoded[..]).unwrap();
-    println!("Decoded: {:?}", decoded);
+
+    assert!(world == decoded);
 }

--- a/readme.md
+++ b/readme.md
@@ -32,23 +32,26 @@ extern crate bincode;
 
 use bincode::{serialize, deserialize, SizeLimit};
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq)]
 struct Entity {
     x: f32,
     y: f32,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, PartialEq)]
 struct World(Vec<Entity>);
 
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
     let encoded: Vec<u8> = serialize(&world, SizeLimit::Infinite).unwrap();
-    println!("Encoded: {:?} ({} bytes)", encoded, encoded.len());
+
+    // 8 bytes for the length of the vector, 4 bytes per float.
+    assert_eq!(encoded.len(), 8 + 4 * 4);
 
     let decoded: World = deserialize(&encoded[..]).unwrap();
-    println!("Decoded: {:?}", decoded);
+
+    assert!(world == decoded);
 }
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -26,38 +26,30 @@ library.
 
 ## Example
 ```rust
+#[macro_use]
+extern crate serde_derive;
 extern crate bincode;
-extern crate rustc_serialize;
 
-use bincode::SizeLimit;
-use bincode::rustc_serialize::{encode, decode};
+use bincode::{serialize, deserialize, SizeLimit};
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq)]
+#[derive(Serialize, Deserialize, Debug)]
 struct Entity {
     x: f32,
     y: f32,
 }
 
-#[derive(RustcEncodable, RustcDecodable, PartialEq)]
-struct World {
-    entities: Vec<Entity>
-}
+#[derive(Serialize, Deserialize, Debug)]
+struct World(Vec<Entity>);
 
 fn main() {
-    let world = World {
-        entities: vec![Entity {x: 0.0, y: 4.0}, Entity {x: 10.0, y: 20.5}]
-    };
+    let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = encode(&world, SizeLimit::Infinite).unwrap();
+    let encoded: Vec<u8> = serialize(&world, SizeLimit::Infinite).unwrap();
+    println!("Encoded: {:?} ({} bytes)", encoded, encoded.len());
 
-    // 8 bytes for the length of the vector, 4 bytes per float.
-    assert_eq!(encoded.len(), 8 + 4 * 4);
-
-    let decoded: World = decode(&encoded[..]).unwrap();
-
-    assert!(world == decoded);
+    let decoded: World = deserialize(&encoded[..]).unwrap();
+    println!("Decoded: {:?}", decoded);
 }
-
 ```
 
 


### PR DESCRIPTION
This PR makes the old example work with serde. It also replaces the asserts 
with some output of the encoded/decoded structs, because asserts are boring and an example needs some action.
