### PR TITLE
Revamp deserialize_char

### DIFF
--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -156,15 +156,14 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
             detail: None
         }.into();
 
-        let mut buf = [0];
+        let mut buf = [0u8; 4];
 
-        let _ = try!(self.reader.read(&mut buf[..]));
+        // Look at the first byte to see how many bytes must be read
+        let _ = try!(self.reader.read(&mut buf[..1]));
         let first_byte = buf[0];
         let width = utf8_char_width(first_byte);
         if width == 1 { return visitor.visit_char(first_byte as char) }
         if width == 0 { return Err(error)}
-
-        let mut buf = [first_byte, 0, 0, 0];
         {
             let mut start = 1;
             while start < width {

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -176,11 +176,7 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
             }
         }
 
-        let res = try!(match str::from_utf8(&buf[..width]).ok() {
-            Some(s) => Ok(s.chars().next().unwrap()),
-            None => Err(error)
-        });
-
+        let res = try!(str::from_utf8(&buf[..width]).ok().and_then(|s| s.chars().next()).ok_or(error));
         visitor.visit_char(res)
     }
 
@@ -229,7 +225,7 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
 
         visitor.visit_enum(self)
     }
-    
+
     fn deserialize_tuple<V>(self,
                       _len: usize,
                       visitor: V) -> Result<V::Value>

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -164,15 +164,9 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
         let width = utf8_char_width(first_byte);
         if width == 1 { return visitor.visit_char(first_byte as char) }
         if width == 0 { return Err(error)}
-        {
-            let mut start = 1;
-            while start < width {
-                match try!(self.reader.read(&mut buf[start .. width])) {
-                    n if n == width - start => break,
-                    n if n < width - start => { start += n; }
-                    _ => return Err(error)
-                }
-            }
+
+        if self.reader.read_exact(&mut buf[1..width]).is_err() {
+            return Err(error);
         }
 
         let res = try!(str::from_utf8(&buf[..width]).ok().and_then(|s| s.chars().next()).ok_or(error));

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -159,7 +159,7 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
         let mut buf = [0u8; 4];
 
         // Look at the first byte to see how many bytes must be read
-        let _ = try!(self.reader.read(&mut buf[..1]));
+        let _ = try!(self.reader.read_exact(&mut buf[..1]));
         let width = utf8_char_width(buf[0]);
         if width == 1 { return visitor.visit_char(buf[0] as char) }
         if width == 0 { return Err(error)}

--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -160,9 +160,8 @@ impl<'a, R: Read, E: ByteOrder> serde::Deserializer for &'a mut Deserializer<R, 
 
         // Look at the first byte to see how many bytes must be read
         let _ = try!(self.reader.read(&mut buf[..1]));
-        let first_byte = buf[0];
-        let width = utf8_char_width(first_byte);
-        if width == 1 { return visitor.visit_char(first_byte as char) }
+        let width = utf8_char_width(buf[0]);
+        if width == 1 { return visitor.visit_char(buf[0] as char) }
         if width == 0 { return Err(error)}
 
         if self.reader.read_exact(&mut buf[1..width]).is_err() {


### PR DESCRIPTION
This PR does the following things in `deserialize_char`:

1. Removes a call to `unwrap()` that was probably impossible to panic 
since `str::from_utf8` checks the encoding, but anyway.
2. Uses a single buffer to read the char into.
3. Replaces the while loop with `read_exact` because the while loop may not
return on malformed input:
```rust
let err = deserialize::<char>(&[0b_1110_0000]).is_err();
println!("{:?}", err);
```

Things I didn't change: 
1. The error gets always created if the compiler isn't smart enough
to move it into the right places. It is boxed, so this means one heap allocation/deallocation
on every call to `deserialize_char`? 
2. The big `UTF8_CHAR_WIDTH` table and the `utf8_char_width` function could be replaced with something like

```rust
match (!buf[0]).leading_zeros() {
    0 => 1,
    2 => 2,
    3 => 3,
    4 => 4,
    _ => error
}
```
