### PR TITLE
Make read_vec more robust

### DIFF
--- a/src/serde/reader.rs
+++ b/src/serde/reader.rs
@@ -41,11 +41,7 @@ impl<R: Read, E: ByteOrder> Deserializer<R, E> {
     }
 
     fn read_bytes(&mut self, count: u64) -> Result<()> {
-        if let (read, false) = self.read.overflowing_add(count) {
-            self.read = read;
-        } else {
-            return Err(ErrorKind::SizeLimit.into());
-        }
+        self.read += count;
         match self.size_limit {
             SizeLimit::Infinite => Ok(()),
             SizeLimit::Bounded(x) if self.read <= x => Ok(()),


### PR DESCRIPTION
This PR makes bincode survive garbage input when decoding types that invoke
the `read_vec` function. Currently `read_vec` allocates a vector of the given
length without any sanity checks, which makes it easy to crash the decoder
with extreme values.

Since the `Read` trait does not provide a way to check the size of the 
remaining data, this PR splits `read_vec` into two functions:

1. `read_vec_small` that read vectors the way bincode currently does,
2. `read_vec_large` that tries to read largish vectors in chunks.

On encountering a large vector size, `read_vec` will call `read_vec_large`
to load the vector in reasonable sized chunks. `read_vec_large` avoids allocating
the vector at once and grows it instead. If length turns out to be garbage, 
bincode will reach the end of the data before it runs out of memory.

Of course, growing a buffer like this will come with a few extra allocations and 
copying, but with a reasonable large buffer size (I picked 64KB out of thin air), 
`read_vec_large` will rarely be invoked.

This PR is a mere suggestion. I don't know your stance on broken inputs and
how bincode should handle them. Some might say "Just add a checksum to your data"
and that's fine, so no feelings hurt if you don't want to merge this.
