### PR TITLE
Use a Config trait to configure bincodes compile-time decisions

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,7 @@
 extern crate serde_derive;
 extern crate bincode;
 
-use bincode::{serialize, deserialize, Infinite};
+use bincode::{serialize, deserialize, DEFAULT_CONFIG};
 
 #[derive(Serialize, Deserialize, PartialEq)]
 struct Entity {
@@ -16,12 +16,12 @@ struct World(Vec<Entity>);
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = serialize(&world, Infinite).unwrap();
+    let encoded: Vec<u8> = serialize(&world, DEFAULT_CONFIG).unwrap();
 
     // 8 bytes for the length of the vector, 4 bytes per float.
     assert_eq!(encoded.len(), 8 + 4 * 4);
 
-    let decoded: World = deserialize(&encoded[..]).unwrap();
+    let decoded: World = deserialize(&encoded[..], DEFAULT_CONFIG).unwrap();
 
     assert!(world == decoded);
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,12 +9,15 @@ use super::internal::ErrorKind;
 ///
 /// Endianness: BigEndian - Big endian is the fastest option on most modern CPU architectures
 /// SizeLimit: Infinite - This default is the least surprising
-pub static DEFAULT_CONFIG: BasicConfig<::byteorder::LittleEndian, Infinite> = BasicConfig {
+pub static DEFAULT_CONFIG: BasicConfig<::byteorder::LittleEndian, Infinite, private::H> = BasicConfig {
     limit: Infinite,
     _phantom_byte_order: PhantomData,
+    _phantom_o: PhantomData,
 };
 
 mod private {
+    #[derive(Copy, Clone)]
+    pub struct H;
     pub trait Hidden {}
 }
 
@@ -32,57 +35,63 @@ pub trait Config: private::Hidden {
 
 /// The only implementation of Config.
 #[derive(Copy, Clone)]
-pub struct BasicConfig<E: ByteOrder, L: SizeLimit> {
+pub struct BasicConfig<E: ByteOrder, L: SizeLimit, O> {
     limit: L,
     _phantom_byte_order: PhantomData<E>,
+    _phantom_o: PhantomData<O>,
 }
 
-impl <E: ByteOrder, L: SizeLimit> private::Hidden for BasicConfig<E, L> {}
+impl <E: ByteOrder, L: SizeLimit, O> private::Hidden for BasicConfig<E, L, O> {}
 
-impl <E: ByteOrder, L: SizeLimit> BasicConfig<E, L> {
+impl <E: ByteOrder, L: SizeLimit, O> BasicConfig<E, L, O> {
     /// Produces a new configuration but with a big endian byte order
-    pub fn with_big_endian(self) -> BasicConfig<::byteorder::BigEndian, L> {
+    pub fn with_big_endian(self) -> BasicConfig<::byteorder::BigEndian, L, O> {
         BasicConfig {
             limit: self.limit,
             _phantom_byte_order: PhantomData,
+            _phantom_o: PhantomData,
         }
     }
 
     /// Produces a new configuration but with a little endian byte order
-    pub fn with_little_endian(self) -> BasicConfig<::byteorder::LittleEndian, L> {
+    pub fn with_little_endian(self) -> BasicConfig<::byteorder::LittleEndian, L, O> {
         BasicConfig {
             limit: self.limit,
             _phantom_byte_order: PhantomData,
+            _phantom_o: PhantomData,
         }
     }
 
     /// Produces a new configuration but with a the byte order specified by the machine
     /// that the code is compiled for.
-    pub fn with_native_endian(self) -> BasicConfig<::byteorder::NativeEndian, L> {
+    pub fn with_native_endian(self) -> BasicConfig<::byteorder::NativeEndian, L, O> {
         BasicConfig {
             limit: self.limit,
             _phantom_byte_order: PhantomData,
+            _phantom_o: PhantomData,
         }
     }
 
     /// Produces a new configuration but with a bounded size limit
-    pub fn with_size_limit(self, limit: u64) -> BasicConfig<E, Bounded> {
+    pub fn with_size_limit(self, limit: u64) -> BasicConfig<E, Bounded, O> {
         BasicConfig {
             limit: Bounded(limit),
             _phantom_byte_order: PhantomData,
+            _phantom_o: PhantomData,
         }
     }
 
     /// Produces a new configuration but without a bounded size limit
-    pub fn without_size_limit(self) -> BasicConfig<E, Infinite> {
+    pub fn without_size_limit(self) -> BasicConfig<E, Infinite, O> {
         BasicConfig {
             limit: Infinite,
             _phantom_byte_order: PhantomData,
+            _phantom_o: PhantomData,
         }
     }
 }
 
-impl <E: ByteOrder, L: SizeLimit> Config for BasicConfig<E, L> {
+impl <E: ByteOrder, L: SizeLimit, O> Config for BasicConfig<E, L, O> {
     type Endianness = E;
     type Limit = L;
     fn limit(&mut self) -> &mut Self::Limit {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use super::internal::ErrorKind;
 
 /// The default configuration options for bincode.
 ///
-/// Endianness: BigEndian - Big endian is the fastest option on most modern CPU architectures
+/// Endianness: LittleEndian - Little endian is the fastest option on most modern CPU architectures
 /// SizeLimit: Infinite - This default is the least surprising
 pub static DEFAULT_CONFIG: BasicConfig<::byteorder::LittleEndian, Infinite, private::H> = BasicConfig {
     limit: Infinite,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,150 @@
+//! Configuration options for serialization and deserialization.
+
+use byteorder::ByteOrder;
+use std::marker::PhantomData;
+use super::internal::Result;
+use super::internal::ErrorKind;
+
+/// The default configuration options for bincode.
+///
+/// Endianness: BigEndian - Big endian is the fastest option on most modern CPU architectures
+/// SizeLimit: Infinite - This default is the least surprising
+pub static DEFAULT_CONFIG: BasicConfig<::byteorder::LittleEndian, Infinite> = BasicConfig {
+    limit: Infinite,
+    _phantom_byte_order: PhantomData,
+};
+
+mod private {
+    pub trait Hidden {}
+}
+
+/// A trait that contains compile-time information about which options to
+/// use while serializing and deserializing
+pub trait Config: private::Hidden {
+    /// Decides how numbers should be serialized
+    type Endianness: ByteOrder;
+    /// A type that implements SizeLimit
+    type Limit: SizeLimit;
+
+    /// Returns the SizeLimit object
+    fn limit(&mut self) -> &mut Self::Limit;
+}
+
+/// The only implementation of Config.
+#[derive(Copy, Clone)]
+pub struct BasicConfig<E: ByteOrder, L: SizeLimit> {
+    limit: L,
+    _phantom_byte_order: PhantomData<E>,
+}
+
+impl <E: ByteOrder, L: SizeLimit> private::Hidden for BasicConfig<E, L> {}
+
+impl <E: ByteOrder, L: SizeLimit> BasicConfig<E, L> {
+    /// Produces a new configuration but with a big endian byte order
+    pub fn with_big_endian(self) -> BasicConfig<::byteorder::BigEndian, L> {
+        BasicConfig {
+            limit: self.limit,
+            _phantom_byte_order: PhantomData,
+        }
+    }
+
+    /// Produces a new configuration but with a little endian byte order
+    pub fn with_little_endian(self) -> BasicConfig<::byteorder::LittleEndian, L> {
+        BasicConfig {
+            limit: self.limit,
+            _phantom_byte_order: PhantomData,
+        }
+    }
+
+    /// Produces a new configuration but with a the byte order specified by the machine
+    /// that the code is compiled for.
+    pub fn with_native_endian(self) -> BasicConfig<::byteorder::NativeEndian, L> {
+        BasicConfig {
+            limit: self.limit,
+            _phantom_byte_order: PhantomData,
+        }
+    }
+
+    /// Produces a new configuration but with a bounded size limit
+    pub fn with_size_limit(self, limit: u64) -> BasicConfig<E, Bounded> {
+        BasicConfig {
+            limit: Bounded(limit),
+            _phantom_byte_order: PhantomData,
+        }
+    }
+
+    /// Produces a new configuration but without a bounded size limit
+    pub fn without_size_limit(self) -> BasicConfig<E, Infinite> {
+        BasicConfig {
+            limit: Infinite,
+            _phantom_byte_order: PhantomData,
+        }
+    }
+}
+
+impl <E: ByteOrder, L: SizeLimit> Config for BasicConfig<E, L> {
+    type Endianness = E;
+    type Limit = L;
+    fn limit(&mut self) -> &mut Self::Limit {
+        &mut self.limit
+    }
+}
+
+/// A limit on the amount of bytes that can be read or written.
+///
+/// Size limits are an incredibly important part of both encoding and decoding.
+///
+/// In order to prevent DOS attacks on a decoder, it is important to limit the
+/// amount of bytes that a single encoded message can be; otherwise, if you
+/// are decoding bytes right off of a TCP stream for example, it would be
+/// possible for an attacker to flood your server with a 3TB vec, causing the
+/// decoder to run out of memory and crash your application!
+/// Because of this, you can provide a maximum-number-of-bytes that can be read
+/// during decoding, and the decoder will explicitly fail if it has to read
+/// any more than that.
+///
+/// On the other side, you want to make sure that you aren't encoding a message
+/// that is larger than your decoder expects.  By supplying a size limit to an
+/// encoding function, the encoder will verify that the structure can be encoded
+/// within that limit.  This verification occurs before any bytes are written to
+/// the Writer, so recovering from an error is easy.
+pub trait SizeLimit {
+    /// Tells the SizeLimit that a certain number of bytes has been
+    /// read or written.  Returns Err if the limit has been exceeded.
+    fn add(&mut self, n: u64) -> Result<()>;
+    /// Returns the hard limit (if one exists)
+    fn limit(&self) -> Option<u64>;
+}
+
+/// A SizeLimit that restricts serialized or deserialized messages from
+/// exceeding a certain byte length.
+#[derive(Copy, Clone)]
+pub struct Bounded(pub u64);
+
+/// A SizeLimit without a limit!
+/// Use this if you don't care about the size of encoded or decoded messages.
+#[derive(Copy, Clone)]
+pub struct Infinite;
+
+impl SizeLimit for Bounded {
+    #[inline(always)]
+    fn add(&mut self, n: u64) -> Result<()> {
+        if self.0 >= n {
+            self.0 -= n;
+            Ok(())
+        } else {
+            Err(Box::new(ErrorKind::SizeLimit))
+        }
+    }
+
+    #[inline(always)]
+    fn limit(&self) -> Option<u64> { Some(self.0) }
+}
+
+impl SizeLimit for Infinite {
+    #[inline(always)]
+    fn add(&mut self, _: u64) -> Result<()> { Ok (()) }
+
+    #[inline(always)]
+    fn limit(&self) -> Option<u64> { None }
+}

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -1,5 +1,5 @@
 use std::io::{Read as IoRead, Result as IoResult, Error as IoError, ErrorKind as IoErrorKind};
-use ::Result;
+use internal::{Result, ErrorKind};
 use serde_crate as serde;
 
 /// A byte-oriented reading trait that is specialized for
@@ -60,15 +60,14 @@ impl <R: IoRead> IoRead for IoReadReader<R> {
 }
 
 impl <'storage> SliceReader<'storage> {
-    fn unexpected_eof() -> Box<::ErrorKind> {
-        return Box::new(::ErrorKind::IoError(IoError::new(IoErrorKind::UnexpectedEof, "")));
+    fn unexpected_eof() -> Box<ErrorKind> {
+        return Box::new(::internal::ErrorKind::IoError(IoError::new(IoErrorKind::UnexpectedEof, "")));
     }
 }
 
 impl <'storage> BincodeRead<'storage> for SliceReader<'storage> {
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) ->  Result<V::Value>
     where V: serde::de::Visitor<'storage> {
-        use ::ErrorKind;
         if length > self.slice.len() {
             return Err(SliceReader::unexpected_eof());
         }
@@ -127,7 +126,7 @@ impl <R> BincodeRead<'static> for IoReadReader<R> where R: IoRead {
 
         let string = match ::std::str::from_utf8(&self.temp_buffer[..length]) {
             Ok(s) => s,
-            Err(_) => return Err(Box::new(::ErrorKind::InvalidEncoding {
+            Err(_) => return Err(Box::new(ErrorKind::InvalidEncoding {
                 desc: "string was not valid utf8",
                 detail: None,
             })),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate serde as serde_crate;
 mod ser;
 mod de;
 mod internal;
-mod config;
+pub mod config;
 
 pub use internal::*;
 use config::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,6 @@
 //! functions which respectively allow encoding into a `std::io::Writer`
 //! and decoding from a `std::io::Buffer`.
 //!
-//! ## Modules
-//! Until "default type parameters" lands, we have an extra module called `endian_choice`
-//! that duplicates all of the core bincode functionality but with the option to choose
-//! which endianness the integers are encoded using.
-//!
-//! The default endianness is little.
-//!
 //! ### Using Basic Functions
 //!
 //! ```rust
@@ -44,7 +37,9 @@ mod internal;
 mod config;
 
 pub use internal::*;
-pub use config::*;
+use config::*;
+
+pub use config::DEFAULT_CONFIG;
 
 pub mod read {
     //! The types that the deserializer uses for optimizations

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,13 @@
 //!
 //! ```rust
 //! extern crate bincode;
-//! use bincode::{serialize, deserialize, Bounded};
+//! use bincode::{serialize, deserialize, DEFAULT_CONFIG};
 //! fn main() {
 //!     // The object that we will serialize.
 //!     let target = Some("hello world".to_string());
-//!     // The maximum size of the encoded message.
-//!     let limit = Bounded(20);
 //!
-//!     let encoded: Vec<u8>        = serialize(&target, limit).unwrap();
-//!     let decoded: Option<String> = deserialize(&encoded[..]).unwrap();
+//!     let encoded: Vec<u8>        = serialize(&target, DEFAULT_CONFIG).unwrap();
+//!     let decoded: Option<String> = deserialize(&encoded[..], DEFAULT_CONFIG).unwrap();
 //!     assert_eq!(target, decoded);
 //! }
 //! ```
@@ -42,126 +40,13 @@ extern crate serde as serde_crate;
 
 mod ser;
 mod de;
-pub mod internal;
+mod internal;
+mod config;
 
-pub mod read_types {
+pub use internal::*;
+pub use config::*;
+
+pub mod read {
     //! The types that the deserializer uses for optimizations
     pub use ::de::read::{SliceReader, BincodeRead, IoReadReader};
-}
-
-use std::io::{Read, Write};
-
-pub use internal::{ErrorKind, Error, Result, serialized_size, serialized_size_bounded};
-
-/// A Deserializer that uses LittleEndian byteorder
-pub type Deserializer<W, S> = internal::Deserializer<W, S, byteorder::LittleEndian>;
-/// A Serializer that uses LittleEndian byteorder
-pub type Serializer<W> = internal::Serializer<W, byteorder::LittleEndian>;
-
-/// Deserializes a slice of bytes into an object.
-///
-/// This method does not have a size-limit because if you already have the bytes
-/// in memory, then you don't gain anything by having a limiter.
-pub fn deserialize<'a, T>(bytes: &'a [u8]) -> internal::Result<T>
-    where T: serde_crate::de::Deserialize<'a>,
-{
-    internal::deserialize::<_, byteorder::LittleEndian>(bytes)
-}
-
-/// Deserializes an object directly from a `Buffer`ed Reader.
-///
-/// If the provided `SizeLimit` is reached, the deserialization will bail immediately.
-/// A SizeLimit can help prevent an attacker from flooding your server with
-/// a neverending stream of values that runs your server out of memory.
-///
-/// If this returns an `Error`, assume that the buffer that you passed
-/// in is in an invalid state, as the error could be returned during any point
-/// in the reading.
-pub fn deserialize_from<R: ?Sized, T, S>(reader: &mut R, size_limit: S) -> internal::Result<T>
-    where R: Read, T: serde_crate::de::DeserializeOwned, S: SizeLimit
-{
-    internal::deserialize_from::<_, _, _, byteorder::LittleEndian>(reader, size_limit)
-}
-
-/// Serializes an object directly into a `Writer`.
-///
-/// If the serialization would take more bytes than allowed by `size_limit`, an error
-/// is returned and *no bytes* will be written into the `Writer`.
-///
-/// If this returns an `Error` (other than SizeLimit), assume that the
-/// writer is in an invalid state, as writing could bail out in the middle of
-/// serializing.
-pub fn serialize_into<W: ?Sized, T: ?Sized, S>(writer: &mut W, value: &T, size_limit: S) -> internal::Result<()>
-    where W: Write, T: serde_crate::Serialize, S: SizeLimit
-{
-    internal::serialize_into::<_, _, _, byteorder::LittleEndian>(writer, value, size_limit)
-}
-
-/// Serializes a serializable object into a `Vec` of bytes.
-///
-/// If the serialization would take more bytes than allowed by `size_limit`,
-/// an error is returned.
-pub fn serialize<T: ?Sized, S>(value: &T, size_limit: S) -> internal::Result<Vec<u8>>
-    where T: serde_crate::Serialize, S: SizeLimit
-{
-    internal::serialize::<_, _, byteorder::LittleEndian>(value, size_limit)
-}
-
-/// A limit on the amount of bytes that can be read or written.
-///
-/// Size limits are an incredibly important part of both encoding and decoding.
-///
-/// In order to prevent DOS attacks on a decoder, it is important to limit the
-/// amount of bytes that a single encoded message can be; otherwise, if you
-/// are decoding bytes right off of a TCP stream for example, it would be
-/// possible for an attacker to flood your server with a 3TB vec, causing the
-/// decoder to run out of memory and crash your application!
-/// Because of this, you can provide a maximum-number-of-bytes that can be read
-/// during decoding, and the decoder will explicitly fail if it has to read
-/// any more than that.
-///
-/// On the other side, you want to make sure that you aren't encoding a message
-/// that is larger than your decoder expects.  By supplying a size limit to an
-/// encoding function, the encoder will verify that the structure can be encoded
-/// within that limit.  This verification occurs before any bytes are written to
-/// the Writer, so recovering from an error is easy.
-pub trait SizeLimit {
-    /// Tells the SizeLimit that a certain number of bytes has been
-    /// read or written.  Returns Err if the limit has been exceeded.
-    fn add(&mut self, n: u64) -> Result<()>;
-    /// Returns the hard limit (if one exists)
-    fn limit(&self) -> Option<u64>;
-}
-
-/// A SizeLimit that restricts serialized or deserialized messages from
-/// exceeding a certain byte length.
-#[derive(Copy, Clone)]
-pub struct Bounded(pub u64);
-
-/// A SizeLimit without a limit!
-/// Use this if you don't care about the size of encoded or decoded messages.
-#[derive(Copy, Clone)]
-pub struct Infinite;
-
-impl SizeLimit for Bounded {
-    #[inline(always)]
-    fn add(&mut self, n: u64) -> Result<()> {
-        if self.0 >= n {
-            self.0 -= n;
-            Ok(())
-        } else {
-            Err(Box::new(ErrorKind::SizeLimit))
-        }
-    }
-
-    #[inline(always)]
-    fn limit(&self) -> Option<u64> { Some(self.0) }
-}
-
-impl SizeLimit for Infinite {
-    #[inline(always)]
-    fn add(&mut self, _: u64) -> Result<()> { Ok (()) }
-
-    #[inline(always)]
-    fn limit(&self) -> Option<u64> { None }
 }


### PR DESCRIPTION
This design will not only reduce the complexity of many type signatures, but it'll also allow us to add more features without breaking back-compat.

This is because the `config` trait is not implementable by customers of the library (it has a trait bound of a hidden type), and the BasicConfig object is not referenceable by type name because it is parameterized by a hidden type.  

What this means practically is that adding another option to bincode like "use variable length encoding" is possible to add as an _option_ without it being a breaking change.
