### PR TITLE
Add Debug derivation to structs of the example in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,13 +32,13 @@ extern crate bincode;
 
 use bincode::{serialize, deserialize, Infinite};
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Entity {
     x: f32,
     y: f32,
 }
 
-#[derive(Serialize, Deserialize, PartialEq)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct World(Vec<Entity>);
 
 fn main() {


### PR DESCRIPTION
The `assert_eq!` macro expects its arguments to satisfy the `Debug` trait as if and when it panics, it'll print out the `Debug` representation.