### PR TITLE
Add .vscode config directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *.swo
 .cargo
+.vscode


### PR DESCRIPTION
This is useful for people who have workspace specific settings when editing with vscode. The most common of which is to turn off format on save since the current code base isn't formatted.