### PR TITLE
Internal type names

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -23,7 +23,7 @@ pub struct SliceReader<'storage> {
 }
 
 /// A BincodeRead implementation for io::Readers
-pub struct IoReadReader<R> {
+pub struct IoReader<R> {
     reader: R,
     temp_buffer: Vec<u8>,
 }
@@ -37,10 +37,10 @@ impl <'storage> SliceReader<'storage> {
     }
 }
 
-impl <R> IoReadReader<R> {
+impl <R> IoReader<R> {
     /// Constructs an IoReadReader
-    pub fn new(r: R) -> IoReadReader<R> {
-        IoReadReader {
+    pub fn new(r: R) -> IoReader<R> {
+        IoReader {
             reader: r,
             temp_buffer: vec![],
         }
@@ -53,7 +53,7 @@ impl <'storage> io::Read for SliceReader<'storage> {
     }
 }
 
-impl <R: io::Read> io::Read for IoReadReader<R> {
+impl <R: io::Read> io::Read for IoReader<R> {
     fn read(&mut self, out: & mut [u8]) -> io::Result<usize> {
         self.reader.read(out)
     }
@@ -107,7 +107,7 @@ impl <'storage> BincodeRead<'storage> for SliceReader<'storage> {
     }
 }
 
-impl <R> IoReadReader<R> where R: io::Read {
+impl <R> IoReader<R> where R: io::Read {
     fn fill_buffer(&mut self, length: usize) -> Result<()> {
         let current_length = self.temp_buffer.len();
         if length > current_length{
@@ -120,7 +120,7 @@ impl <R> IoReadReader<R> where R: io::Read {
     }
 }
 
-impl <R> BincodeRead<'static> for IoReadReader<R> where R: io::Read {
+impl <R> BincodeRead<'static> for IoReader<R> where R: io::Read {
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) ->  Result<V::Value>
     where V: serde::de::Visitor<'static> {
         self.fill_buffer(length)?;

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -2,8 +2,7 @@
 //! that use the `serde` crate for the serializable and deserializable
 //! implementation.
 
-use std::io::{Write, Read};
-use std::io::Error as IoError;
+use std::io::{self, Write, Read};
 use std::{error, fmt, result};
 use ::{CountSize, SizeLimit};
 use byteorder::{ByteOrder};
@@ -34,7 +33,7 @@ pub type Error = Box<ErrorKind>;
 pub enum ErrorKind {
     /// If the error stems from the reader/writer that is being used
     /// during (de)serialization, that error will be stored and returned here.
-    Io(IoError),
+    Io(io::Error),
     /// If the bytes in the reader are not decodable because of an invalid
     /// encoding, this error will be returned.  This error is only possible
     /// if a stream is corrupted.  A stream produced from `encode` or `encode_into`
@@ -77,8 +76,8 @@ impl error::Error for ErrorKind {
     }
 }
 
-impl From<IoError> for Error {
-    fn from(err: IoError) -> Error {
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
         ErrorKind::Io(err).into()
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -215,7 +215,7 @@ pub fn serialized_size_bounded<T: ?Sized>(value: &T, max: u64) -> Option<u64>
 pub fn deserialize_from<R: ?Sized, T, S, E>(reader: &mut R, size_limit: S) -> Result<T>
     where R: Read, T: serde::de::DeserializeOwned, S: SizeLimit, E: ByteOrder
 {
-    let reader = ::de::read::IoReadReader::new(reader);
+    let reader = ::de::read::IoReader::new(reader);
     let mut deserializer = Deserializer::<_, S, E>::new(reader, size_limit);
     serde::Deserialize::deserialize(&mut deserializer)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod internal;
 
 pub mod read_types {
     //! The types that the deserializer uses for optimizations
-    pub use ::de::read::{SliceReader, BincodeRead, IoReadReader};
+    pub use ::de::read::{SliceReader, BincodeRead, IoReader};
 }
 
 use std::io::{Read, Write};
@@ -175,7 +175,7 @@ mod private {
     pub trait Sealed {}
 
     impl<'a> Sealed for super::de::read::SliceReader<'a> {}
-    impl<R> Sealed for super::de::read::IoReadReader<R> {}
+    impl<R> Sealed for super::de::read::IoReader<R> {}
     impl Sealed for super::Infinite {}
     impl Sealed for super::Bounded {}
     impl Sealed for super::CountSize {}


### PR DESCRIPTION
Closes #163 

I also took the opportunity to rename `IoReadReader` to the less redundant `IoReader`.