### PR TITLE
Forward read_exact() as well as read().

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -51,11 +51,17 @@ impl <'storage> io::Read for SliceReader<'storage> {
     fn read(&mut self, out: & mut [u8]) -> io::Result<usize> {
         (&mut self.slice).read(out)
     }
+    fn read_exact(&mut self, out: & mut [u8]) -> io::Result<()> {
+        (&mut self.slice).read_exact(out)
+    }
 }
 
 impl <R: io::Read> io::Read for IoReader<R> {
     fn read(&mut self, out: & mut [u8]) -> io::Result<usize> {
         self.reader.read(out)
+    }
+    fn read_exact(&mut self, out: & mut [u8]) -> io::Result<()> {
+        self.reader.read_exact(out)
     }
 }
 


### PR DESCRIPTION
If we don't do this we end up using the generic read_exact method
which is not necessarily optimal. This is especially when
using a specialized Read implementation to go fast.
See https://github.com/TyOverby/bincode/issues/206