### PR TITLE
2nd implementation of the Config Trait

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -2,7 +2,7 @@
 extern crate serde_derive;
 extern crate bincode;
 
-use bincode::{deserialize, serialize, Infinite};
+use bincode::{deserialize, serialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Entity {
@@ -16,7 +16,7 @@ struct World(Vec<Entity>);
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = serialize(&world, Infinite).unwrap();
+    let encoded: Vec<u8> = serialize(&world).unwrap();
 
     // 8 bytes for the length of the vector (usize), 4 bytes per float.
     assert_eq!(encoded.len(), 8 + 4 * 4);

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,64 @@
+use super::{SizeLimit, Infinite, Bounded};
+use byteorder::{ByteOrder, BigEndian, LittleEndian, NativeEndian};
+use std::marker::PhantomData;
+
+trait Options {
+    type Limit: SizeLimit + 'static;
+    type Endian: ByteOrder + 'static;
+
+    fn limit(&mut self) -> &mut Self::Limit;
+}
+
+pub trait Config {
+    fn with_no_limit(self: Box<Self>) -> Box<Config>;
+    fn with_limit(self: Box<Self>, u64) -> Box<Config>;
+    fn with_little_endian(self: Box<Self>) -> Box<Config>;
+    fn with_big_endian(self: Box<Self>) -> Box<Config>;
+    fn with_native_endian(self: Box<Self>) -> Box<Config>;
+}
+
+pub(crate) struct ConfigImpl<L: SizeLimit + 'static, E: ByteOrder + 'static> {
+    limit: L,
+    _e: PhantomData<E>,
+}
+
+impl <L: SizeLimit, E: ByteOrder> ConfigImpl<L, E> {
+    fn new(limit: L) -> ConfigImpl<L, E> {
+        ConfigImpl {
+            limit: limit,
+            _e: PhantomData,
+        }
+    }
+}
+
+impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Config for ConfigImpl<L, E> {
+    fn with_no_limit(self: Box<Self>) -> Box<Config> {
+        let r: ConfigImpl<Infinite, E> = ConfigImpl::new(Infinite);
+        Box::new(r)
+    }
+    fn with_limit(self: Box<Self>, limit: u64) -> Box<Config> {
+        let r: ConfigImpl<Bounded, E> = ConfigImpl::new(Bounded(limit));
+        Box::new(r)
+    }
+    fn with_little_endian(self: Box<Self>) -> Box<Config> {
+        let r: ConfigImpl<L, LittleEndian> = ConfigImpl::new(self.limit);
+        Box::new(r)
+    }
+    fn with_big_endian(self: Box<Self>) -> Box<Config> {
+        let r: ConfigImpl<L, BigEndian> = ConfigImpl::new(self.limit);
+        Box::new(r)
+    }
+    fn with_native_endian(self: Box<Self>) -> Box<Config> {
+        let r: ConfigImpl<L, NativeEndian> = ConfigImpl::new(self.limit);
+        Box::new(r)
+    }
+}
+
+impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Options for ConfigImpl<L, E> {
+    type Limit = L;
+    type Endian = E;
+
+    fn limit(&mut self) -> &mut L {
+        &mut self.limit
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,6 @@ pub(crate) trait Options {
     type Limit: SizeLimit + 'static;
     type Endian: ByteOrder + 'static;
 
-    #[inline(always)]
     fn limit(&mut self) -> &mut Self::Limit;
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,27 +19,22 @@ pub(crate) trait Options {
 }
 
 pub(crate) trait OptionsExt: Options + Sized {
-    #[inline(always)]
     fn with_no_limit(self) -> WithOtherLimit<Self, Infinite> {
         WithOtherLimit::new(self, Infinite)
     }
 
-    #[inline(always)]
     fn with_limit(self, limit: u64) -> WithOtherLimit<Self, Bounded> {
         WithOtherLimit::new(self, Bounded(limit))
     }
 
-    #[inline(always)]
     fn with_little_endian(self) -> WithOtherEndian<Self, LittleEndian> {
         WithOtherEndian::new(self)
     }
 
-    #[inline(always)]
     fn with_big_endian(self) -> WithOtherEndian<Self, BigEndian> {
         WithOtherEndian::new(self)
     }
 
-    #[inline(always)]
     fn with_native_endian(self) -> WithOtherEndian<Self, NativeEndian> {
         WithOtherEndian::new(self)
     }
@@ -185,47 +180,37 @@ impl Config {
 
     /// TODO: Document
     #[inline(always)]
-    pub fn with_no_limit(self) -> Config {
-        Config {
-            limit: LimitOption::Unlimited,
-            ..self
-        }
+    pub fn no_limit(&mut self) -> &mut Self {
+        self.limit = LimitOption::Unlimited;
+        self
     }
 
     /// TODO: Document
     #[inline(always)]
-    pub fn with_limit(self, limit: u64) -> Config {
-        Config {
-            limit: LimitOption::Limited(limit),
-            ..self
-        }
+    pub fn limit(&mut self, limit: u64) -> &mut Self {
+        self.limit = LimitOption::Limited(limit);
+        self
     }
 
     /// TODO: Document
     #[inline(always)]
-    pub fn with_little_endian(self) -> Config {
-        Config {
-            endian: EndianOption::Little,
-            ..self
-        }
+    pub fn little_endian(&mut self) -> &mut Self {
+        self.endian= EndianOption::Little;
+        self
     }
 
     /// TODO: Document
     #[inline(always)]
-    pub fn with_big_endian(self) -> Config {
-        Config {
-            endian: EndianOption::Big,
-            ..self
-        }
+    pub fn big_endian(&mut self) -> &mut Self {
+        self.endian= EndianOption::Big;
+        self
     }
 
     /// TODO: Document
     #[inline(always)]
-    pub fn with_native_endian(self) -> Config {
-        Config {
-            endian: EndianOption::Native,
-            ..self
-        }
+    pub fn native_endian(&mut self) -> &mut Self {
+        self.endian = EndianOption::Native;
+        self
     }
 
     /// TODO: Document

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,8 +150,8 @@ impl<O: Options, L: SizeLimit + 'static> Options for WithOtherLimit<O, L> {
 }
 
 macro_rules! config_map {
-    ($limit:expr, $endian:expr, $opts:ident => $call:expr) => {
-        match ($limit, $endian) {
+    ($self:expr, $opts:ident => $call:expr) => {
+        match ($self.limit, $self.endian) {
             (Unlimited, Little) => {
                 let $opts = DefaultOptions::new().with_no_limit().with_little_endian();
                 $call
@@ -230,13 +230,13 @@ impl Config {
     /// Serializes a serializable object into a `Vec` of bytes using this configuration
     #[inline(always)]
     pub fn serialize<T: ?Sized + serde::Serialize>(&self, t: &T) -> Result<Vec<u8>> {
-        config_map!(self.limit, self.endian, opts => ::internal::serialize(t, opts))
+        config_map!(self, opts => ::internal::serialize(t, opts))
     }
 
     /// Returns the size that an object would be if serialized using Bincode with this configuration
     #[inline(always)]
     pub fn serialized_size<T: ?Sized + serde::Serialize>(&self, t: &T) -> Result<u64> {
-        config_map!(self.limit, self.endian, opts => ::internal::serialized_size(t, opts))
+        config_map!(self, opts => ::internal::serialized_size(t, opts))
     }
 
     /// Serializes an object directly into a `Writer` using this configuration
@@ -245,13 +245,13 @@ impl Config {
     /// is returned and *no bytes* will be written into the `Writer`
     #[inline(always)]
     pub fn serialize_into<W: Write, T: ?Sized + serde::Serialize>(&self, w: W, t: &T) -> Result<()> {
-        config_map!(self.limit, self.endian, opts => ::internal::serialize_into(w, t, opts))
+        config_map!(self, opts => ::internal::serialize_into(w, t, opts))
     }
 
     /// Deserializes a slice of bytes into an instance of `T` using this configuration
     #[inline(always)]
     pub fn deserialize<'a, T: serde::Deserialize<'a>>(&self, bytes: &'a [u8]) -> Result<T> {
-        config_map!(self.limit, self.endian, opts => ::internal::deserialize(bytes, opts))
+        config_map!(self, opts => ::internal::deserialize(bytes, opts))
     }
 
     /// Deserializes an object directly from a `Read`er using this configuration
@@ -259,7 +259,7 @@ impl Config {
     /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
     pub fn deserialize_from<R: Read, T: serde::de::DeserializeOwned>(&self, reader: R) -> Result<T> {
-        config_map!(self.limit, self.endian, opts => ::internal::deserialize_from(reader, opts))
+        config_map!(self, opts => ::internal::deserialize_from(reader, opts))
     }
 
     /// Deserializes an object from a custom `BincodeRead`er using this configuration
@@ -267,6 +267,6 @@ impl Config {
     /// If this returns an `Error`, `reader` may be in an invalid state
     #[inline(always)]
     pub fn deserialize_from_custom<'a, R: BincodeRead<'a>, T: serde::de::DeserializeOwned>(&self, reader: R) -> Result<T> {
-        config_map!(self.limit, self.endian, opts => ::internal::deserialize_from_custom(reader, opts))
+        config_map!(self, opts => ::internal::deserialize_from_custom(reader, opts))
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use super::{SizeLimit, Infinite, Bounded};
 use byteorder::{ByteOrder, BigEndian, LittleEndian, NativeEndian};
 use std::marker::PhantomData;
 
-trait Options {
+pub(crate) trait Options {
     type Limit: SizeLimit + 'static;
     type Endian: ByteOrder + 'static;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,9 +262,11 @@ impl Config {
         config_map!(self, opts => ::internal::deserialize_from(reader, opts))
     }
 
-    /// Deserializes an object from a custom `BincodeRead`er using this configuration
-    ///
-    /// If this returns an `Error`, `reader` may be in an invalid state
+    /// Deserializes an object from a custom `BincodeRead`er using the default configuration.
+    /// It is highly recommended to use `deserialize_from` unless you need to implement
+    /// `BincodeRead` for performance reasons.
+    /// 
+    /// If this returns an `Error`, `reader` may be in an invalid state.
     #[inline(always)]
     pub fn deserialize_from_custom<'a, R: BincodeRead<'a>, T: serde::de::DeserializeOwned>(&self, reader: R) -> Result<T> {
         config_map!(self, opts => ::internal::deserialize_from_custom(reader, opts))

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use super::{SizeLimit, Infinite, Bounded};
 use byteorder::{ByteOrder, BigEndian, LittleEndian, NativeEndian};
+use serde;
 use std::marker::PhantomData;
 
 pub(crate) trait Options {
@@ -7,6 +8,15 @@ pub(crate) trait Options {
     type Endian: ByteOrder + 'static;
 
     fn limit(&mut self) -> &mut Self::Limit;
+}
+
+impl <'a, O: Options> Options for &'a mut O {
+    type Limit = O::Limit;
+    type Endian = O::Endian;
+
+    fn limit(&mut self) -> &mut Self::Limit {
+        self.limit()
+    }
 }
 
 pub trait Config {
@@ -17,11 +27,43 @@ pub trait Config {
     fn with_native_endian(self: Box<Self>) -> Box<Config>;
 }
 
+struct DefaultOptions {
+    infinite: Infinite
+}
+
+pub(crate) struct WithOtherLimit<O: Options, L: SizeLimit> {
+    _options: O,
+    pub (crate) new_limit: L,
+}
+
+pub(crate) struct WithOtherEndian<O: Options, E: ByteOrder> {
+    options: O,
+    _endian: PhantomData<E>,
+}
+
+// This is a "shallow" config impl.  This matters when boxing.
 pub(crate) struct ConfigImpl<L: SizeLimit + 'static, E: ByteOrder + 'static> {
     limit: L,
     _e: PhantomData<E>,
+ }
+
+impl Options for DefaultOptions {
+    type Limit = Infinite;
+    type Endian = LittleEndian;
+
+    fn limit(&mut self) -> &mut Self::Limit {
+        &mut self.infinite
+    }
 }
 
+impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Options for ConfigImpl<L, E> {
+    type Limit = L;
+    type Endian = E;
+
+    fn limit(&mut self) -> &mut Self::Limit {
+        &mut self.limit
+    }
+}
 impl <L: SizeLimit, E: ByteOrder> ConfigImpl<L, E> {
     fn new(limit: L) -> ConfigImpl<L, E> {
         ConfigImpl {
@@ -31,7 +73,106 @@ impl <L: SizeLimit, E: ByteOrder> ConfigImpl<L, E> {
     }
 }
 
-impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Config for ConfigImpl<L, E> {
+impl <O: Options, L: SizeLimit> WithOtherLimit<O, L> {
+    pub(crate) fn new(options: O, limit: L) -> WithOtherLimit<O, L> {
+        WithOtherLimit {
+            _options: options,
+            new_limit: limit
+        }
+    }
+}
+
+impl <O: Options, E: ByteOrder> WithOtherEndian<O, E> {
+    pub(crate) fn new(options: O) -> WithOtherEndian<O, E> {
+        WithOtherEndian {
+            options: options,
+            _endian: PhantomData
+        }
+    }
+}
+
+impl <O: Options, E: ByteOrder + 'static> Options for WithOtherEndian<O, E> {
+    type Limit = O::Limit;
+    type Endian = E;
+
+    fn limit(&mut self) -> &mut O::Limit {
+        self.options.limit()
+    }
+}
+
+impl <O: Options, L: SizeLimit + 'static> Options for WithOtherLimit<O, L> {
+    type Limit = L;
+    type Endian = O::Endian;
+
+    fn limit(&mut self) -> &mut L {
+        &mut self.new_limit
+    }
+}
+
+impl Config for DefaultOptions {
+    fn with_no_limit(self: Box<Self>) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Infinite))
+    }
+    fn with_limit(self: Box<Self>, limit: u64) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Bounded(limit)))
+    }
+    fn with_little_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, LittleEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_big_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, BigEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_native_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, NativeEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+}
+
+impl <O: Options + 'static, L: SizeLimit + 'static> Config for WithOtherLimit<O, L>{
+    fn with_no_limit(self: Box<Self>) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Infinite))
+    }
+    fn with_limit(self: Box<Self>, limit: u64) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Bounded(limit)))
+    }
+    fn with_little_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, LittleEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_big_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, BigEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_native_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, NativeEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+}
+
+impl <O: Options + 'static, E: ByteOrder + 'static> Config for WithOtherEndian<O, E>{
+    fn with_no_limit(self: Box<Self>) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Infinite))
+    }
+    fn with_limit(self: Box<Self>, limit: u64) -> Box<Config> {
+        Box::new(WithOtherLimit::new(*self, Bounded(limit)))
+    }
+    fn with_little_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, LittleEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_big_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, BigEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+    fn with_native_endian(self: Box<Self>) -> Box<Config> {
+        let r: WithOtherEndian<_, NativeEndian> = WithOtherEndian::new(*self);
+        Box::new(r)
+    }
+}
+
+impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Config for ConfigImpl<L, E>{
     fn with_no_limit(self: Box<Self>) -> Box<Config> {
         let r: ConfigImpl<Infinite, E> = ConfigImpl::new(Infinite);
         Box::new(r)
@@ -51,14 +192,5 @@ impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Config for ConfigImpl<L, E
     fn with_native_endian(self: Box<Self>) -> Box<Config> {
         let r: ConfigImpl<L, NativeEndian> = ConfigImpl::new(self.limit);
         Box::new(r)
-    }
-}
-
-impl <L: SizeLimit + 'static, E: ByteOrder + 'static> Options for ConfigImpl<L, E> {
-    type Limit = L;
-    type Endian = E;
-
-    fn limit(&mut self) -> &mut L {
-        &mut self.limit
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -221,14 +221,8 @@ impl Config {
 
     /// TODO: Document
     #[inline(always)]
-    pub fn serialized_size<T: ?Sized + serde::Serialize>(&self, t: &T) -> u64 {
+    pub fn serialized_size<T: ?Sized + serde::Serialize>(&self, t: &T) -> Result<u64> {
         config_map!(self.limit, self.endian, opts => ::internal::serialized_size(t, opts))
-    }
-
-    /// TODO: Document
-    #[inline(always)]
-    pub fn serialized_size_bounded<T: ?Sized + serde::Serialize>(&self, t: &T, bound: u64) -> Option<u64> {
-        config_map!(self.limit, self.endian, opts => ::internal::serialized_size_bounded(t, bound, opts))
     }
 
     /// TODO: Document

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,12 +1,13 @@
 use std::io::Read;
-use std::marker::PhantomData;
+use ::config::Options;
 
-use byteorder::{ReadBytesExt, ByteOrder};
-use serde_crate as serde;
-use serde_crate::de::IntoDeserializer;
-use serde_crate::de::Error as DeError;
+use serde;
+use byteorder::ReadBytesExt;
+use serde::de::IntoDeserializer;
+use serde::de::Error as DeError;
 use SizeLimit;
-use super::{Result, Error, ErrorKind};
+use super::{Error, ErrorKind};
+use super::error::Result;
 use self::read::BincodeRead;
 
 pub mod read;
@@ -24,24 +25,22 @@ pub mod read;
 /// serde::Deserialize::deserialize(&mut deserializer);
 /// let bytes_read = d.bytes_read();
 /// ```
-pub struct Deserializer<R, S: SizeLimit, E: ByteOrder> {
+pub(crate) struct Deserializer<R, O: Options> {
     reader: R,
-    size_limit: S,
-    _phantom: PhantomData<E>,
+    options: O,
 }
 
-impl<'de, R: BincodeRead<'de>, E: ByteOrder, S: SizeLimit> Deserializer<R, S, E> {
+impl<'de, R: BincodeRead<'de>, O: Options> Deserializer<R, O> {
     /// Creates a new Deserializer with a given `Read`er and a size_limit.
-    pub fn new(r: R, size_limit: S) -> Deserializer<R, S, E> {
+    pub(crate) fn new(r: R, options: O) -> Deserializer<R, O> {
         Deserializer {
             reader: r,
-            size_limit: size_limit,
-            _phantom: PhantomData,
+            options: options,
         }
     }
 
     fn read_bytes(&mut self, count: u64) -> Result<()> {
-        self.size_limit.add(count)
+        self.options.limit().add(count)
     }
 
     fn read_type<T>(&mut self) -> Result<()> {
@@ -68,17 +67,16 @@ macro_rules! impl_nums {
             where V: serde::de::Visitor<'de>,
         {
             try!(self.read_type::<$ty>());
-            let value = try!(self.reader.$reader_method::<E>());
+            let value = try!(self.reader.$reader_method::<O::Endian>());
             visitor.$visitor_method(value)
         }
     }
 }
 
-impl<'de, 'a, R, S, E> serde::Deserializer<'de> for &'a mut Deserializer<R, S, E>
+impl<'de, 'a, R, O> serde::Deserializer<'de> for &'a mut Deserializer<R, O>
 where
     R: BincodeRead<'de>,
-    S: SizeLimit,
-    E: ByteOrder,
+    O: Options,
 {
     type Error = Error;
 
@@ -211,8 +209,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        impl<'de, 'a, R: 'a, S, E> serde::de::EnumAccess<'de> for &'a mut Deserializer<R, S, E>
-        where R: BincodeRead<'de>, S: SizeLimit, E: ByteOrder {
+        impl<'de, 'a, R: 'a, O> serde::de::EnumAccess<'de> for &'a mut Deserializer<R, O>
+        where R: BincodeRead<'de>, O: Options {
             type Error = Error;
             type Variant = Self;
 
@@ -232,8 +230,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        struct Access<'a, R: Read + 'a, S: SizeLimit + 'a, E: ByteOrder + 'a> {
-            deserializer: &'a mut Deserializer<R, S, E>,
+        struct Access<'a, R: Read + 'a, O: Options + 'a> {
+            deserializer: &'a mut Deserializer<R, O>,
             len: usize,
         }
 
@@ -242,9 +240,8 @@ where
             'a,
             'b: 'a,
             R: BincodeRead<'de> + 'b,
-            S: SizeLimit,
-            E: ByteOrder,
-        > serde::de::SeqAccess<'de> for Access<'a, R, S, E> {
+            O: Options,
+        > serde::de::SeqAccess<'de> for Access<'a, R, O> {
             type Error = Error;
 
             fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -299,8 +296,8 @@ where
     where
         V: serde::de::Visitor<'de>,
     {
-        struct Access<'a, R: Read + 'a, S: SizeLimit + 'a, E: ByteOrder + 'a> {
-            deserializer: &'a mut Deserializer<R, S, E>,
+        struct Access<'a, R: Read + 'a, O: Options + 'a> {
+            deserializer: &'a mut Deserializer<R, O>,
             len: usize,
         }
 
@@ -309,9 +306,8 @@ where
             'a,
             'b: 'a,
             R: BincodeRead<'de> + 'b,
-            S: SizeLimit,
-            E: ByteOrder,
-        > serde::de::MapAccess<'de> for Access<'a, R, S, E> {
+            O: Options,
+        > serde::de::MapAccess<'de> for Access<'a, R, O> {
             type Error = Error;
 
             fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>>
@@ -409,8 +405,8 @@ where
     }
 }
 
-impl<'de, 'a, R, S, E> serde::de::VariantAccess<'de> for &'a mut Deserializer<R, S, E>
-where R: BincodeRead<'de>, S: SizeLimit, E: ByteOrder {
+impl<'de, 'a, R, O> serde::de::VariantAccess<'de> for &'a mut Deserializer<R, O>
+where R: BincodeRead<'de>, O: Options{
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -5,9 +5,8 @@ use serde;
 use byteorder::ReadBytesExt;
 use serde::de::IntoDeserializer;
 use serde::de::Error as DeError;
-use SizeLimit;
-use super::{Error, ErrorKind};
-use super::error::Result;
+use ::{Error, ErrorKind, Result};
+use ::internal::SizeLimit;
 use self::read::BincodeRead;
 
 pub mod read;

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -2,15 +2,20 @@ use std::io;
 use error::Result;
 use serde;
 
-/// A byte-oriented reading trait that is specialized for
-/// slices and generic readers.
-pub(crate) trait BincodeRead<'storage>: io::Read {
+/// An optional Read trait for advanced Bincode usage.
+///
+/// It is highly recommended to use bincode with `io::Read` or `&[u8]` before
+/// implementing a custom `BincodeRead`.
+pub trait BincodeRead<'storage>: io::Read {
+    /// Forwards reading `length` bytes of a string on to the serde reader.
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>;
 
+    /// Return the first `length` bytes of the internal byte buffer.
     fn get_byte_buffer(&mut self, length: usize) -> Result<Vec<u8>>;
 
+    /// Forwards reading `length` bytes on to the serde reader.
     fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>;
@@ -56,9 +61,11 @@ impl<'storage> io::Read for SliceReader<'storage> {
 }
 
 impl<R: io::Read> io::Read for IoReader<R> {
+    #[inline(always)]
     fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
         self.reader.read(out)
     }
+    #[inline(always)]
     fn read_exact(&mut self, out: &mut [u8]) -> io::Result<()> {
         self.reader.read_exact(out)
     }

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -1,10 +1,10 @@
 use std::io;
-use Result;
-use serde_crate as serde;
+use error::Result;
+use serde;
 
 /// A byte-oriented reading trait that is specialized for
 /// slices and generic readers.
-pub trait BincodeRead<'storage>: io::Read + ::private::Sealed {
+pub(crate) trait BincodeRead<'storage>: io::Read {
     #[doc(hidden)]
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where

--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -5,15 +5,12 @@ use serde;
 /// A byte-oriented reading trait that is specialized for
 /// slices and generic readers.
 pub(crate) trait BincodeRead<'storage>: io::Read {
-    #[doc(hidden)]
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>;
 
-    #[doc(hidden)]
     fn get_byte_buffer(&mut self, length: usize) -> Result<Vec<u8>>;
 
-    #[doc(hidden)]
     fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>;
@@ -48,9 +45,11 @@ impl<R> IoReader<R> {
 }
 
 impl<'storage> io::Read for SliceReader<'storage> {
+    #[inline(always)]
     fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
         (&mut self.slice).read(out)
     }
+    #[inline(always)]
     fn read_exact(&mut self, out: &mut [u8]) -> io::Result<()> {
         (&mut self.slice).read_exact(out)
     }
@@ -66,6 +65,7 @@ impl<R: io::Read> io::Read for IoReader<R> {
 }
 
 impl<'storage> SliceReader<'storage> {
+    #[inline(always)]
     fn unexpected_eof() -> Box<::ErrorKind> {
         return Box::new(::ErrorKind::Io(
             io::Error::new(io::ErrorKind::UnexpectedEof, ""),
@@ -74,6 +74,7 @@ impl<'storage> SliceReader<'storage> {
 }
 
 impl<'storage> BincodeRead<'storage> for SliceReader<'storage> {
+    #[inline(always)]
     fn forward_read_str<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>,
@@ -92,6 +93,7 @@ impl<'storage> BincodeRead<'storage> for SliceReader<'storage> {
         r
     }
 
+    #[inline(always)]
     fn get_byte_buffer(&mut self, length: usize) -> Result<Vec<u8>> {
         if length > self.slice.len() {
             return Err(SliceReader::unexpected_eof());
@@ -102,6 +104,7 @@ impl<'storage> BincodeRead<'storage> for SliceReader<'storage> {
         Ok(r.to_vec())
     }
 
+    #[inline(always)]
     fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
     where
         V: serde::de::Visitor<'storage>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,119 @@
+use std::io;
+use std::{error, fmt};
+use std::str::Utf8Error;
+use std::error::Error as StdError;
+
+use serde;
+
+/// The result of a serialization or deserialization operation.
+pub type Result<T> = ::std::result::Result<T, Error>;
+
+/// An error that can be produced during (de)serializing.
+pub type Error = Box<ErrorKind>;
+
+/// The kind of error that can be produced during a serialization or deserialization.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// If the error stems from the reader/writer that is being used
+    /// during (de)serialization, that error will be stored and returned here.
+    Io(io::Error),
+    /// Returned if the deserializer attempts to deserialize a string that is not valid utf8
+    InvalidUtf8Encoding(Utf8Error),
+    /// Returned if the deserializer attempts to deserialize a bool that was
+    /// not encoded as either a 1 or a 0
+    InvalidBoolEncoding(u8),
+    /// Returned if the deserializer attempts to deserialize a char that is not in the correct format.
+    InvalidCharEncoding,
+    /// Returned if the deserializer attempts to deserialize the tag of an enum that is
+    /// not in the expected ranges
+    InvalidTagEncoding(usize),
+    /// Serde has a deserialize_any method that lets the format hint to the
+    /// object which route to take in deserializing.
+    DeserializeAnyNotSupported,
+    /// If (de)serializing a message takes more than the provided size limit, this
+    /// error is returned.
+    SizeLimit,
+    /// Bincode can not encode sequences of unknown length (like iterators).
+    SequenceMustHaveLength,
+    /// A custom error message from Serde.
+    Custom(String),
+}
+
+impl StdError for ErrorKind {
+    fn description(&self) -> &str {
+        match *self {
+            ErrorKind::Io(ref err) => error::Error::description(err),
+            ErrorKind::InvalidUtf8Encoding(_) => "string is not valid utf8",
+            ErrorKind::InvalidBoolEncoding(_) => "invalid u8 while decoding bool",
+            ErrorKind::InvalidCharEncoding => "char is not valid",
+            ErrorKind::InvalidTagEncoding(_) => "tag for enum is not valid",
+            ErrorKind::SequenceMustHaveLength =>
+                "Bincode can only encode sequences and maps that have a knowable size ahead of time",
+            ErrorKind::DeserializeAnyNotSupported => {
+                "Bincode doesn't support serde::Deserializer::deserialize_any"
+            }
+            ErrorKind::SizeLimit => "the size limit has been reached",
+            ErrorKind::Custom(ref msg) => msg,
+
+        }
+    }
+
+    fn cause(&self) -> Option<&error::Error> {
+        match *self {
+            ErrorKind::Io(ref err) => Some(err),
+            ErrorKind::InvalidUtf8Encoding(_) => None,
+            ErrorKind::InvalidBoolEncoding(_) => None,
+            ErrorKind::InvalidCharEncoding => None,
+            ErrorKind::InvalidTagEncoding(_) => None,
+            ErrorKind::SequenceMustHaveLength => None,
+            ErrorKind::DeserializeAnyNotSupported => None,
+            ErrorKind::SizeLimit => None,
+            ErrorKind::Custom(_) => None,
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        ErrorKind::Io(err).into()
+    }
+}
+
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ErrorKind::Io(ref ioerr) => write!(fmt, "io error: {}", ioerr),
+            ErrorKind::InvalidUtf8Encoding(ref e) => write!(fmt, "{}: {}", self.description(), e),
+            ErrorKind::InvalidBoolEncoding(b) => {
+                write!(fmt, "{}, expected 0 or 1, found {}", self.description(), b)
+            }
+            ErrorKind::InvalidCharEncoding => write!(fmt, "{}", self.description()),
+            ErrorKind::InvalidTagEncoding(tag) => {
+                write!(fmt, "{}, found {}", self.description(), tag)
+            }
+            ErrorKind::SequenceMustHaveLength => {
+                write!(fmt, "{}", self.description())
+            }
+            ErrorKind::SizeLimit => write!(fmt, "{}", self.description()),
+            ErrorKind::DeserializeAnyNotSupported => {
+                write!(
+                    fmt,
+                    "Bincode does not support the serde::Deserializer::deserialize_any method"
+                )
+            }
+            ErrorKind::Custom(ref s) => s.fmt(fmt),
+        }
+    }
+}
+
+impl serde::de::Error for Error {
+    fn custom<T: fmt::Display>(desc: T) -> Error {
+        ErrorKind::Custom(desc.to_string()).into()
+    }
+}
+
+impl serde::ser::Error for Error {
+    fn custom<T: fmt::Display>(msg: T) -> Self {
+        ErrorKind::Custom(msg.to_string()).into()
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -1,9 +1,8 @@
 use std::io::{Write, Read};
 use serde;
 
-use ::config::Options;
-use ::{ErrorKind, Result, Infinite};
-use ::SizeLimit;
+use ::config::{Options, OptionsExt};
+use ::{ErrorKind, Result};
 
 struct CountSize {
     total: u64,
@@ -56,12 +55,11 @@ where
         }
     };
 
-    let options = ::config::WithOtherLimit::new(&mut options, Infinite);
-    serialize_into( &mut writer, value, options)?;
+    serialize_into( &mut writer, value, options.with_no_limit())?;
     Ok(writer)
 }
 
-impl ::SizeLimit for CountSize {
+impl SizeLimit for CountSize {
     fn add(&mut self, c: u64) -> Result<()> {
         self.total += c;
         if let Some(limit) = self.limit {
@@ -151,4 +149,71 @@ where
     let options = ::config::WithOtherLimit::new(options, Infinite);
     let mut deserializer = ::de::Deserializer::new(reader, options);
     serde::Deserialize::deserialize(&mut deserializer)
+}
+
+
+/// A limit on the amount of bytes that can be read or written.
+///
+/// Size limits are an incredibly important part of both encoding and decoding.
+///
+/// In order to prevent DOS attacks on a decoder, it is important to limit the
+/// amount of bytes that a single encoded message can be; otherwise, if you
+/// are decoding bytes right off of a TCP stream for example, it would be
+/// possible for an attacker to flood your server with a 3TB vec, causing the
+/// decoder to run out of memory and crash your application!
+/// Because of this, you can provide a maximum-number-of-bytes that can be read
+/// during decoding, and the decoder will explicitly fail if it has to read
+/// any more than that.
+///
+/// On the other side, you want to make sure that you aren't encoding a message
+/// that is larger than your decoder expects.  By supplying a size limit to an
+/// encoding function, the encoder will verify that the structure can be encoded
+/// within that limit.  This verification occurs before any bytes are written to
+/// the Writer, so recovering from an error is easy.
+pub(crate) trait SizeLimit {
+    /// Tells the SizeLimit that a certain number of bytes has been
+    /// read or written.  Returns Err if the limit has been exceeded.
+    fn add(&mut self, n: u64) -> Result<()>;
+    /// Returns the hard limit (if one exists)
+    fn limit(&self) -> Option<u64>;
+}
+
+
+/// A SizeLimit that restricts serialized or deserialized messages from
+/// exceeding a certain byte length.
+#[derive(Copy, Clone)]
+pub struct Bounded(pub u64);
+
+/// A SizeLimit without a limit!
+/// Use this if you don't care about the size of encoded or decoded messages.
+#[derive(Copy, Clone)]
+pub struct Infinite;
+
+impl SizeLimit for Bounded {
+    #[inline(always)]
+    fn add(&mut self, n: u64) -> Result<()> {
+        if self.0 >= n {
+            self.0 -= n;
+            Ok(())
+        } else {
+            Err(Box::new(ErrorKind::SizeLimit))
+        }
+    }
+
+    #[inline(always)]
+    fn limit(&self) -> Option<u64> {
+        Some(self.0)
+    }
+}
+
+impl SizeLimit for Infinite {
+    #[inline(always)]
+    fn add(&mut self, _: u64) -> Result<()> {
+        Ok(())
+    }
+
+    #[inline(always)]
+    fn limit(&self) -> Option<u64> {
+        None
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ mod de;
 mod internal;
 
 pub use error::{Error, ErrorKind};
+pub use config::Config;
 use error::Result;
 
 /// A limit on the amount of bytes that can be read or written.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,9 @@
 #![deny(missing_docs)]
 
 //! Bincode is a crate for encoding and decoding using a tiny binary
-//! serialization strategy.
-//!
-//! There are simple functions for encoding to `Vec<u8>` and decoding from
-//! `&[u8]`, but the meat of the library is the `serialize_into` and `deserialize_from`
-//! functions which respectively allow encoding into any `std::io::Write`
-//! or decode from any `std::io::Read`.
-//!
-//! ## Modules
-//! Until "default type parameters" lands, we have an extra module called `endian_choice`
-//! that duplicates all of the core Bincode functionality but with the option to choose
-//! which endianness the integers are encoded using.
-//!
-//! The default endianness is little.
+//! serialization strategy.  Using it, you can easily go from having
+//! an object in memory, quickly serialize it to bytes, and then
+//! deserialize it back just as fast!
 //!
 //! ### Using Basic Functions
 //!
@@ -22,7 +12,7 @@
 //! use bincode::{serialize, deserialize};
 //! fn main() {
 //!     // The object that we will serialize.
-//!     let target: Option<String> = Some("hello world".to_string());
+//!     let target: Option<String>  = Some("hello world".to_string());
 //!
 //!     let encoded: Vec<u8>        = serialize(&target).unwrap();
 //!     let decoded: Option<String> = deserialize(&encoded[..]).unwrap();
@@ -47,8 +37,9 @@ pub use error::{Error, ErrorKind, Result};
 pub use config::Config;
 pub use de::read::BincodeRead;
 
-/// The default bincode configuration.
+/// Get a default configuration object.
 ///
+/// ### Default Configuration:
 /// Byte limit: Unlimited
 /// Endianness: Little
 pub fn config() -> Config {
@@ -87,6 +78,8 @@ where
 }
 
 /// Deserializes an object from a custom `BincodeRead`er using the default configuration.
+/// It is highly recommended to use `deserialize_from` unless you need to implement
+/// `BincodeRead` for performance reasons.
 ///
 /// If this returns an `Error`, `reader` may be in an invalid state.
 pub fn deserialize_from_custom<'a, R, T>(reader: R) -> Result<T>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! use bincode::{serialize, deserialize};
 //! fn main() {
 //!     // The object that we will serialize.
-//!     let target = Some("hello world".to_string());
+//!     let target: Option<String> = Some("hello world".to_string());
 //!
 //!     let encoded: Vec<u8>        = serialize(&target).unwrap();
 //!     let decoded: Option<String> = deserialize(&encoded[..]).unwrap();
@@ -45,20 +45,20 @@ mod internal;
 
 pub use error::{Error, ErrorKind, Result};
 pub use config::Config;
+pub use de::read::BincodeRead;
 
-/// TODO: Document
+/// The default bincode configuration.
+///
+/// Byte limit: Unlimited
+/// Endianness: Little
 pub fn config() -> Config {
     Config::new()
 }
 
 /// Serializes an object directly into a `Writer` using the default configuration.
 ///
-/// If the serialization would take more bytes than allowed by `size_limit`, an error
+/// If the serialization would take more bytes than allowed by the size limit, an error
 /// is returned and *no bytes* will be written into the `Writer`.
-///
-/// If this returns an `Error` (other than SizeLimit), assume that the
-/// writer is in an invalid state, as writing could bail out in the middle of
-/// serializing.
 pub fn serialize_into<W, T: ?Sized, O>(writer: W, value: &T) -> Result<()>
 where
     W: std::io::Write,
@@ -68,9 +68,6 @@ where
 }
 
 /// Serializes a serializable object into a `Vec` of bytes using the default configuration.
-///
-/// If the serialization would take more bytes than allowed by `size_limit`,
-/// an error is returned.
 pub fn serialize<T: ?Sized>(value: &T) -> Result<Vec<u8>>
 where
     T: serde::Serialize,
@@ -80,13 +77,7 @@ where
 
 /// Deserializes an object directly from a `Read`er using the default configuration.
 ///
-/// If the provided `SizeLimit` is reached, the deserialization will bail immediately.
-/// A SizeLimit can help prevent an attacker from flooding your server with
-/// a neverending stream of values that runs your server out of memory.
-///
-/// If this returns an `Error`, assume that the buffer that you passed
-/// in is in an invalid state, as the error could be returned during any point
-/// in the reading.
+/// If this returns an `Error`, `reader` may be in an invalid state.
 pub fn deserialize_from<R, T>(reader: R) -> Result<T>
 where
     R: std::io::Read,
@@ -95,10 +86,18 @@ where
     config().deserialize_from(reader)
 }
 
-/// Deserializes a slice of bytes into an object.
+/// Deserializes an object from a custom `BincodeRead`er using the default configuration.
 ///
-/// This method does not have a size-limit because if you already have the bytes
-/// in memory, then you don't gain anything by having a limiter.
+/// If this returns an `Error`, `reader` may be in an invalid state.
+pub fn deserialize_from_custom<'a, R, T>(reader: R) -> Result<T>
+where
+    R: de::read::BincodeRead<'a>,
+    T: serde::de::DeserializeOwned,
+{
+    config().deserialize_from_custom(reader)
+}
+
+/// Deserializes a slice of bytes into an instance of `T` using the default configuration.
 pub fn deserialize<'a, T>(bytes: &'a [u8]) -> Result<T>
 where
     T: serde::de::Deserialize<'a>,
@@ -106,10 +105,7 @@ where
     config().deserialize(bytes)
 }
 
-/// Returns the size that an object would be if serialized using Bincode.
-///
-/// This is used internally as part of the check for encode_into, but it can
-/// be useful for preallocating buffers if thats your style.
+/// Returns the size that an object would be if serialized using Bincode with the default configuration.
 pub fn serialized_size<T: ?Sized>(value: &T) -> Result<u64>
 where
     T: serde::Serialize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,19 +110,9 @@ where
 ///
 /// This is used internally as part of the check for encode_into, but it can
 /// be useful for preallocating buffers if thats your style.
-pub fn serialized_size<T: ?Sized>(value: &T) -> u64
-where T: serde::Serialize,
+pub fn serialized_size<T: ?Sized>(value: &T) -> Result<u64>
+where
+    T: serde::Serialize,
 {
     config().serialized_size(value)
-}
-
-/// Given a maximum size limit, check how large an object would be if it
-/// were to be serialized.
-///
-/// If it can be serialized in `max` or fewer bytes, that number will be returned
-/// inside `Some`.  If it goes over bounds, then None is returned.
-pub fn serialized_size_bounded<T: ?Sized>(value: &T, max: u64) -> Option<u64>
-where T: serde::Serialize,
-{
-    config().serialized_size_bounded(value, max)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@
 extern crate byteorder;
 extern crate serde as serde_crate;
 
+mod config;
 mod ser;
 mod de;
 pub mod internal;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -7,7 +7,7 @@ use byteorder::WriteBytesExt;
 
 use super::{Result, Error, ErrorKind};
 use ::config::Options;
-use super::SizeLimit;
+use super::internal::SizeLimit;
 
 /// An Serializer that encodes values directly into a Writer.
 ///

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -1,12 +1,12 @@
 use std::io::Write;
 use std::u32;
-use std::marker::PhantomData;
 
-use serde_crate as serde;
+use serde;
 
-use byteorder::{WriteBytesExt, ByteOrder};
+use byteorder::WriteBytesExt;
 
 use super::{Result, Error, ErrorKind};
+use ::config::Options;
 use super::SizeLimit;
 
 /// An Serializer that encodes values directly into a Writer.
@@ -16,31 +16,31 @@ use super::SizeLimit;
 ///
 /// This struct should not be used often.
 /// For most cases, prefer the `encode_into` function.
-pub struct Serializer<W, E: ByteOrder> {
+pub(crate) struct Serializer<W, O: Options> {
     writer: W,
-    _phantom: PhantomData<E>,
+    _options: O,
 }
 
-impl<W: Write, E: ByteOrder> Serializer<W, E> {
+impl<W: Write, O: Options> Serializer<W, O> {
     /// Creates a new Serializer with the given `Write`r.
-    pub fn new(w: W) -> Serializer<W, E> {
+    pub fn new(w: W, options: O) -> Serializer<W, O> {
         Serializer {
             writer: w,
-            _phantom: PhantomData,
+            _options: options,
         }
     }
 }
 
-impl<'a, W: Write, E: ByteOrder> serde::Serializer for &'a mut Serializer<W, E> {
+impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
     type Ok = ();
     type Error = Error;
-    type SerializeSeq = Compound<'a, W, E>;
-    type SerializeTuple = Compound<'a, W, E>;
-    type SerializeTupleStruct = Compound<'a, W, E>;
-    type SerializeTupleVariant = Compound<'a, W, E>;
-    type SerializeMap = Compound<'a, W, E>;
-    type SerializeStruct = Compound<'a, W, E>;
-    type SerializeStructVariant = Compound<'a, W, E>;
+    type SerializeSeq = Compound<'a, W, O>;
+    type SerializeTuple = Compound<'a, W, O>;
+    type SerializeTupleStruct = Compound<'a, W, O>;
+    type SerializeTupleVariant = Compound<'a, W, O>;
+    type SerializeMap = Compound<'a, W, O>;
+    type SerializeStruct = Compound<'a, W, O>;
+    type SerializeStructVariant = Compound<'a, W, O>;
 
     fn serialize_unit(self) -> Result<()> {
         Ok(())
@@ -61,15 +61,15 @@ impl<'a, W: Write, E: ByteOrder> serde::Serializer for &'a mut Serializer<W, E> 
     }
 
     fn serialize_u16(self, v: u16) -> Result<()> {
-        self.writer.write_u16::<E>(v).map_err(Into::into)
+        self.writer.write_u16::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_u32(self, v: u32) -> Result<()> {
-        self.writer.write_u32::<E>(v).map_err(Into::into)
+        self.writer.write_u32::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_u64(self, v: u64) -> Result<()> {
-        self.writer.write_u64::<E>(v).map_err(Into::into)
+        self.writer.write_u64::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i8(self, v: i8) -> Result<()> {
@@ -77,23 +77,23 @@ impl<'a, W: Write, E: ByteOrder> serde::Serializer for &'a mut Serializer<W, E> 
     }
 
     fn serialize_i16(self, v: i16) -> Result<()> {
-        self.writer.write_i16::<E>(v).map_err(Into::into)
+        self.writer.write_i16::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i32(self, v: i32) -> Result<()> {
-        self.writer.write_i32::<E>(v).map_err(Into::into)
+        self.writer.write_i32::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_i64(self, v: i64) -> Result<()> {
-        self.writer.write_i64::<E>(v).map_err(Into::into)
+        self.writer.write_i64::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {
-        self.writer.write_f32::<E>(v).map_err(Into::into)
+        self.writer.write_f32::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_f64(self, v: f64) -> Result<()> {
-        self.writer.write_f64::<E>(v).map_err(Into::into)
+        self.writer.write_f64::<O::Endian>(v).map_err(Into::into)
     }
 
     fn serialize_str(self, v: &str) -> Result<()> {
@@ -205,17 +205,17 @@ impl<'a, W: Write, E: ByteOrder> serde::Serializer for &'a mut Serializer<W, E> 
     }
 }
 
-pub struct SizeChecker<S: SizeLimit> {
-    pub size_limit: S,
+pub(crate) struct SizeChecker<O: Options> {
+    pub options: O,
 }
 
-impl<S: SizeLimit> SizeChecker<S> {
-    pub fn new(size_limit: S) -> SizeChecker<S> {
-        SizeChecker { size_limit: size_limit }
+impl<O: Options> SizeChecker<O> {
+    pub fn new(options: O) -> SizeChecker<O> {
+        SizeChecker { options: options }
     }
 
     fn add_raw(&mut self, size: u64) -> Result<()> {
-        self.size_limit.add(size)
+        self.options.limit().add(size)
     }
 
     fn add_value<T>(&mut self, t: T) -> Result<()> {
@@ -224,16 +224,16 @@ impl<S: SizeLimit> SizeChecker<S> {
     }
 }
 
-impl<'a, S: SizeLimit> serde::Serializer for &'a mut SizeChecker<S> {
+impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
     type Ok = ();
     type Error = Error;
-    type SerializeSeq = SizeCompound<'a, S>;
-    type SerializeTuple = SizeCompound<'a, S>;
-    type SerializeTupleStruct = SizeCompound<'a, S>;
-    type SerializeTupleVariant = SizeCompound<'a, S>;
-    type SerializeMap = SizeCompound<'a, S>;
-    type SerializeStruct = SizeCompound<'a, S>;
-    type SerializeStructVariant = SizeCompound<'a, S>;
+    type SerializeSeq = SizeCompound<'a, O>;
+    type SerializeTuple = SizeCompound<'a, O>;
+    type SerializeTupleStruct = SizeCompound<'a, O>;
+    type SerializeTupleVariant = SizeCompound<'a, O>;
+    type SerializeMap = SizeCompound<'a, O>;
+    type SerializeStruct = SizeCompound<'a, O>;
+    type SerializeStructVariant = SizeCompound<'a, O>;
 
     fn serialize_unit(self) -> Result<()> {
         Ok(())
@@ -394,15 +394,14 @@ impl<'a, S: SizeLimit> serde::Serializer for &'a mut SizeChecker<S> {
     }
 }
 
-#[doc(hidden)]
-pub struct Compound<'a, W: 'a, E: ByteOrder + 'a> {
-    ser: &'a mut Serializer<W, E>,
+pub(crate) struct Compound<'a, W: 'a, O: Options + 'a> {
+    ser: &'a mut Serializer<W, O>,
 }
 
-impl<'a, W, E> serde::ser::SerializeSeq for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeSeq for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -421,10 +420,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeTuple for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeTuple for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -443,10 +442,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeTupleStruct for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeTupleStruct for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -465,10 +464,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeTupleVariant for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeTupleVariant for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -487,10 +486,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeMap for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeMap for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -517,10 +516,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeStruct for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeStruct for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -539,10 +538,10 @@ where
     }
 }
 
-impl<'a, W, E> serde::ser::SerializeStructVariant for Compound<'a, W, E>
+impl<'a, W, O> serde::ser::SerializeStructVariant for Compound<'a, W, O>
 where
     W: Write,
-    E: ByteOrder,
+    O: Options,
 {
     type Ok = ();
     type Error = Error;
@@ -561,12 +560,11 @@ where
     }
 }
 
-#[doc(hidden)]
-pub struct SizeCompound<'a, S: SizeLimit + 'a> {
+pub(crate) struct SizeCompound<'a, S: Options + 'a> {
     ser: &'a mut SizeChecker<S>,
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeSeq for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeSeq for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -584,7 +582,7 @@ impl<'a, S: SizeLimit> serde::ser::SerializeSeq for SizeCompound<'a, S> {
     }
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeTuple for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeTuple for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -602,7 +600,7 @@ impl<'a, S: SizeLimit> serde::ser::SerializeTuple for SizeCompound<'a, S> {
     }
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeTupleStruct for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeTupleStruct for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -620,7 +618,7 @@ impl<'a, S: SizeLimit> serde::ser::SerializeTupleStruct for SizeCompound<'a, S> 
     }
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeTupleVariant for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeTupleVariant for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -638,7 +636,7 @@ impl<'a, S: SizeLimit> serde::ser::SerializeTupleVariant for SizeCompound<'a, S>
     }
 }
 
-impl<'a, S: SizeLimit + 'a> serde::ser::SerializeMap for SizeCompound<'a, S> {
+impl<'a, O: Options+ 'a> serde::ser::SerializeMap for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -664,7 +662,7 @@ impl<'a, S: SizeLimit + 'a> serde::ser::SerializeMap for SizeCompound<'a, S> {
     }
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeStruct for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeStruct for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 
@@ -682,7 +680,7 @@ impl<'a, S: SizeLimit> serde::ser::SerializeStruct for SizeCompound<'a, S> {
     }
 }
 
-impl<'a, S: SizeLimit> serde::ser::SerializeStructVariant for SizeCompound<'a, S> {
+impl<'a, O: Options> serde::ser::SerializeStructVariant for SizeCompound<'a, O> {
     type Ok = ();
     type Error = Error;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -35,10 +35,10 @@ where
     }
 
     {
-        let encoded = config().with_big_endian().serialize(&element).unwrap();
-        let decoded = config().with_big_endian().deserialize(&encoded[..]).unwrap();
+        let encoded = config().big_endian().serialize(&element).unwrap();
+        let decoded = config().big_endian().deserialize(&encoded[..]).unwrap();
         let decoded_reader =
-            config().with_big_endian().deserialize_from(&mut &encoded[..]).unwrap();
+            config().big_endian().deserialize_from(&mut &encoded[..]).unwrap();
 
         assert_eq!(element, decoded);
         assert_eq!(element, decoded_reader);
@@ -246,12 +246,12 @@ fn deserializing_errors() {
 fn too_big_deserialize() {
     let serialized = vec![0, 0, 0, 3];
     let deserialized: Result<u32> =
-        config().with_limit(3).deserialize_from(&mut &serialized[..]);
+        config().limit(3).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_err());
 
     let serialized = vec![0, 0, 0, 3];
     let deserialized: Result<u32> =
-        config().with_limit(4).deserialize_from(&mut &serialized[..]);
+        config().limit(4).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
 }
 
@@ -259,7 +259,7 @@ fn too_big_deserialize() {
 fn char_serialization() {
     let chars = "Aa\0☺♪";
     for c in chars.chars() {
-        let encoded = config().with_limit(4).serialize(&c).expect("serializing char failed");
+        let encoded = config().limit(4).serialize(&c).expect("serializing char failed");
         let decoded: char = deserialize(&encoded).expect("deserializing failed");
         assert_eq!(decoded, c);
     }
@@ -269,18 +269,18 @@ fn char_serialization() {
 fn too_big_char_deserialize() {
     let serialized = vec![0x41];
     let deserialized: Result<char> =
-        config().with_limit(1).deserialize_from(&mut &serialized[..]);
+        config().limit(1).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
 #[test]
 fn too_big_serialize() {
-    assert!(config().with_limit(3).serialize(&0u32).is_err());
-    assert!(config().with_limit(4).serialize(&0u32).is_ok());
+    assert!(config().limit(3).serialize(&0u32).is_err());
+    assert!(config().limit(4).serialize(&0u32).is_ok());
 
-    assert!(config().with_limit(8 + 4).serialize(&"abcde").is_err());
-    assert!(config().with_limit(8 + 5).serialize(&"abcde").is_ok());
+    assert!(config().limit(8 + 4).serialize(&"abcde").is_err());
+    assert!(config().limit(8 + 5).serialize(&"abcde").is_ok());
 }
 
 #[test]
@@ -380,13 +380,13 @@ fn test_oom_protection() {
         len: u64,
         byte: u8,
     }
-    let x = config().with_limit(10).serialize(
+    let x = config().limit(10).serialize(
         &FakeVec {
             len: 0xffffffffffffffffu64,
             byte: 1,
         }
     ).unwrap();
-    let y: Result<Vec<u8>> = config().with_limit(10).deserialize_from(&mut Cursor::new(&x[..]));
+    let y: Result<Vec<u8>> = config().limit(10).deserialize_from(&mut Cursor::new(&x[..]));
     assert!(y.is_err());
 }
 
@@ -420,7 +420,7 @@ fn serde_bytes() {
 fn endian_difference() {
     let x = 10u64;
     let little = serialize(&x).unwrap();
-    let big = config().with_big_endian().serialize(&x).unwrap();
+    let big = config().big_endian().serialize(&x).unwrap();
     assert_ne!(little, big);
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -10,13 +10,15 @@ use std::fmt::Debug;
 use std::collections::HashMap;
 use std::borrow::Cow;
 
-use bincode::{Bounded, Infinite};
-use bincode::{serialized_size, ErrorKind, Result};
-use bincode::internal::{deserialize, deserialize_from, serialize};
-
-use bincode::serialize as serialize_little;
-use bincode::deserialize as deserialize_little;
-use bincode::deserialize_from as deserialize_from_little;
+use bincode::{
+    serialize,
+    deserialize,
+    deserialize_from,
+    config,
+    serialized_size,
+    ErrorKind,
+    Result,
+};
 
 fn the_same<V>(element: V)
 where
@@ -25,25 +27,24 @@ where
     let size = serialized_size(&element);
 
     {
-        let encoded = serialize_little(&element, Infinite).unwrap();
-        let decoded = deserialize_little(&encoded[..]).unwrap();
+        let encoded = serialize(&element).unwrap();
+        let decoded = deserialize(&encoded[..]).unwrap();
 
         assert_eq!(element, decoded);
         assert_eq!(size, encoded.len() as u64);
     }
 
     {
-        let encoded = serialize::<_, _, byteorder::BigEndian>(&element, Infinite).unwrap();
-        let decoded = deserialize::<_, byteorder::BigEndian>(&encoded[..]).unwrap();
+        let encoded = config().with_big_endian().serialize(&element).unwrap();
+        let decoded = config().with_big_endian().deserialize(&encoded[..]).unwrap();
         let decoded_reader =
-            deserialize_from::<_, _, _, byteorder::BigEndian>(&mut &encoded[..], Infinite).unwrap();
+            config().with_big_endian().deserialize_from(&mut &encoded[..]).unwrap();
 
         assert_eq!(element, decoded);
         assert_eq!(element, decoded_reader);
         assert_eq!(size, encoded.len() as u64);
     }
 }
-
 #[test]
 fn test_numbers() {
     // unsigned positive
@@ -214,11 +215,11 @@ fn test_fixed_size_array() {
 #[test]
 fn deserializing_errors() {
 
-    match *deserialize_little::<bool>(&vec![0xA][..]).unwrap_err() {
+    match *deserialize::<bool>(&vec![0xA][..]).unwrap_err() {
         ErrorKind::InvalidBoolEncoding(0xA) => {}
         _ => panic!(),
     }
-    match *deserialize_little::<String>(&vec![1, 0, 0, 0, 0, 0, 0, 0, 0xFF][..]).unwrap_err() {
+    match *deserialize::<String>(&vec![1, 0, 0, 0, 0, 0, 0, 0, 0xFF][..]).unwrap_err() {
         ErrorKind::InvalidUtf8Encoding(_) => {}
         _ => panic!(),
     }
@@ -230,12 +231,12 @@ fn deserializing_errors() {
         Two,
     };
 
-    match *deserialize_little::<Test>(&vec![0, 0, 0, 5][..]).unwrap_err() {
+    match *deserialize::<Test>(&vec![0, 0, 0, 5][..]).unwrap_err() {
         // Error message comes from serde
         ErrorKind::Custom(_) => {}
         _ => panic!(),
     }
-    match *deserialize_little::<Option<u8>>(&vec![5, 0][..]).unwrap_err() {
+    match *deserialize::<Option<u8>>(&vec![5, 0][..]).unwrap_err() {
         ErrorKind::InvalidTagEncoding(_) => {}
         _ => panic!(),
     }
@@ -245,12 +246,12 @@ fn deserializing_errors() {
 fn too_big_deserialize() {
     let serialized = vec![0, 0, 0, 3];
     let deserialized: Result<u32> =
-        deserialize_from_little::<_, _, _>(&mut &serialized[..], Bounded(3));
+        config().with_limit(3).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_err());
 
     let serialized = vec![0, 0, 0, 3];
     let deserialized: Result<u32> =
-        deserialize_from_little::<_, _, _>(&mut &serialized[..], Bounded(4));
+        config().with_limit(4).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
 }
 
@@ -258,8 +259,8 @@ fn too_big_deserialize() {
 fn char_serialization() {
     let chars = "Aa\0☺♪";
     for c in chars.chars() {
-        let encoded = serialize_little(&c, Bounded(4)).expect("serializing char failed");
-        let decoded: char = deserialize_little(&encoded).expect("deserializing failed");
+        let encoded = config().with_limit(4).serialize(&c).expect("serializing char failed");
+        let decoded: char = deserialize(&encoded).expect("deserializing failed");
         assert_eq!(decoded, c);
     }
 }
@@ -268,33 +269,18 @@ fn char_serialization() {
 fn too_big_char_deserialize() {
     let serialized = vec![0x41];
     let deserialized: Result<char> =
-        deserialize_from_little::<_, _, _>(&mut &serialized[..], Bounded(1));
+        config().with_limit(1).deserialize_from(&mut &serialized[..]);
     assert!(deserialized.is_ok());
     assert_eq!(deserialized.unwrap(), 'A');
 }
 
 #[test]
 fn too_big_serialize() {
-    assert!(serialize_little(&0u32, Bounded(3)).is_err());
-    assert!(serialize_little(&0u32, Bounded(4)).is_ok());
+    assert!(config().with_limit(3).serialize(&0u32).is_err());
+    assert!(config().with_limit(4).serialize(&0u32).is_ok());
 
-    assert!(serialize_little(&"abcde", Bounded(8 + 4)).is_err());
-    assert!(serialize_little(&"abcde", Bounded(8 + 5)).is_ok());
-}
-
-#[test]
-fn test_proxy_encoded_size() {
-    assert!(serialized_size(&0u8) == 1);
-    assert!(serialized_size(&0u16) == 2);
-    assert!(serialized_size(&0u32) == 4);
-    assert!(serialized_size(&0u64) == 8);
-
-    // length isize stored as u64
-    assert!(serialized_size(&"") == 8);
-    assert!(serialized_size(&"a") == 8 + 1);
-
-    assert!(serialized_size(&vec![0u32, 1u32, 2u32]) == 8 + 3 * (4))
-
+    assert!(config().with_limit(8 + 4).serialize(&"abcde").is_err());
+    assert!(config().with_limit(8 + 5).serialize(&"abcde").is_ok());
 }
 
 #[test]
@@ -332,9 +318,9 @@ fn test_cow_serialize() {
     // Test 1
     {
         let serialized =
-            serialize_little(&Message::M1(Cow::Borrowed(&large_object)), Infinite).unwrap();
+            serialize(&Message::M1(Cow::Borrowed(&large_object))).unwrap();
         let deserialized: Message<'static> =
-            deserialize_from_little(&mut &serialized[..], Infinite).unwrap();
+            deserialize_from(&mut &serialized[..]).unwrap();
 
         match deserialized {
             Message::M1(b) => assert!(&b.into_owned() == &large_object),
@@ -345,9 +331,9 @@ fn test_cow_serialize() {
     // Test 2
     {
         let serialized =
-            serialize_little(&Message::M2(Cow::Borrowed(&large_map)), Infinite).unwrap();
+            serialize(&Message::M2(Cow::Borrowed(&large_map))).unwrap();
         let deserialized: Message<'static> =
-            deserialize_from_little(&mut &serialized[..], Infinite).unwrap();
+            deserialize_from(&mut &serialized[..]).unwrap();
 
         match deserialized {
             Message::M2(b) => assert!(&b.into_owned() == &large_map),
@@ -359,9 +345,9 @@ fn test_cow_serialize() {
 #[test]
 fn test_strbox_serialize() {
     let strx: &'static str = "hello world";
-    let serialized = serialize_little(&Cow::Borrowed(strx), Infinite).unwrap();
+    let serialized = serialize(&Cow::Borrowed(strx)).unwrap();
     let deserialized: Cow<'static, String> =
-        deserialize_from_little(&mut &serialized[..], Infinite).unwrap();
+        deserialize_from(&mut &serialized[..]).unwrap();
     let stringx: String = deserialized.into_owned();
     assert!(strx == &stringx[..]);
 }
@@ -369,10 +355,10 @@ fn test_strbox_serialize() {
 #[test]
 fn test_slicebox_serialize() {
     let slice = [1u32, 2, 3, 4, 5];
-    let serialized = serialize_little(&Cow::Borrowed(&slice[..]), Infinite).unwrap();
+    let serialized = serialize(&Cow::Borrowed(&slice[..])).unwrap();
     println!("{:?}", serialized);
     let deserialized: Cow<'static, Vec<u32>> =
-        deserialize_from_little(&mut &serialized[..], Infinite).unwrap();
+        deserialize_from(&mut &serialized[..]).unwrap();
     {
         let sb: &[u32] = &deserialized;
         assert!(slice == sb);
@@ -383,7 +369,7 @@ fn test_slicebox_serialize() {
 
 #[test]
 fn test_multi_strings_serialize() {
-    assert!(serialize_little(&("foo", "bar", "baz"), Infinite).is_ok());
+    assert!(serialize(&("foo", "bar", "baz")).is_ok());
 }
 
 #[test]
@@ -394,14 +380,13 @@ fn test_oom_protection() {
         len: u64,
         byte: u8,
     }
-    let x = serialize_little(
+    let x = config().with_limit(10).serialize(
         &FakeVec {
             len: 0xffffffffffffffffu64,
             byte: 1,
-        },
-        Bounded(10),
+        }
     ).unwrap();
-    let y: Result<Vec<u8>> = deserialize_from_little(&mut Cursor::new(&x[..]), Bounded(10));
+    let y: Result<Vec<u8>> = config().with_limit(10).deserialize_from(&mut Cursor::new(&x[..]));
     assert!(y.is_err());
 }
 
@@ -409,8 +394,8 @@ fn test_oom_protection() {
 fn path_buf() {
     use std::path::{Path, PathBuf};
     let path = Path::new("foo").to_path_buf();
-    let serde_encoded = serialize_little(&path, Infinite).unwrap();
-    let decoded: PathBuf = deserialize_little(&serde_encoded).unwrap();
+    let serde_encoded = serialize(&path).unwrap();
+    let decoded: PathBuf = deserialize(&serde_encoded).unwrap();
     assert!(path.to_str() == decoded.to_str());
 }
 
@@ -419,8 +404,8 @@ fn bytes() {
     use serde_bytes::Bytes;
 
     let data = b"abc\0123";
-    let s = serialize_little(&data[..], Infinite).unwrap();
-    let s2 = serialize_little(&Bytes::new(data), Infinite).unwrap();
+    let s = serialize(&data[..]).unwrap();
+    let s2 = serialize(&Bytes::new(data)).unwrap();
     assert_eq!(s[..], s2[..]);
 }
 
@@ -434,8 +419,8 @@ fn serde_bytes() {
 #[test]
 fn endian_difference() {
     let x = 10u64;
-    let little = serialize_little(&x, Infinite).unwrap();
-    let big = serialize::<_, _, byteorder::BigEndian>(&x, Infinite).unwrap();
+    let little = serialize(&x).unwrap();
+    let big = config().with_big_endian().serialize(&x).unwrap();
     assert_ne!(little, big);
 }
 
@@ -452,8 +437,8 @@ fn test_zero_copy_parse() {
         borrowed_bytes: &[0, 1, 2, 3],
     };
     {
-        let encoded = serialize_little(&f, Infinite).unwrap();
-        let out: Foo = deserialize_little(&encoded[..]).unwrap();
+        let encoded = serialize(&f).unwrap();
+        let out: Foo = deserialize(&encoded[..]).unwrap();
         assert_eq!(out, f);
     }
 }


### PR DESCRIPTION
closes #160 
closes #156 
closes #164

Basic gist of it is that you can write the following 

```rust
use bincode::{serialize, config};

serialize(&vec![1,2,3]);
// or 
config().big_endian().limit(12).serialize(&vec![1,2,3]);
```

depending on if you want to configure bincode.

Adding new configuration options should be backwards compatible.  All of this should be 0 cost (assuming that the inliner does its work correctly)