### PR TITLE
Allow serialized types to use a more compact representation ...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ description = "A binary serialization / deserialization strategy that uses Serde
 
 [dependencies]
 byteorder = "1.0.0"
-serde = "1.*.*"
+serde = "1.0.16"
 
 [dev-dependencies]
 serde_bytes = "0.10.*"
-serde_derive = "1.*.*"
+serde_derive = "1.0.16"
+

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -407,6 +407,10 @@ where
         let message = "Bincode does not support Deserializer::deserialize_ignored_any";
         Err(Error::custom(message))
     }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 impl<'de, 'a, R, S, E> serde::de::VariantAccess<'de> for &'a mut Deserializer<R, S, E>

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -203,6 +203,10 @@ impl<'a, W: Write, E: ByteOrder> serde::Serializer for &'a mut Serializer<W, E> 
     ) -> Result<()> {
         self.serialize_u32(variant_index)
     }
+
+    fn is_human_readable(&self) -> bool {
+        false
+    }
 }
 
 pub struct SizeChecker<S: SizeLimit> {
@@ -391,6 +395,10 @@ impl<'a, S: SizeLimit> serde::Serializer for &'a mut SizeChecker<S> {
     ) -> Result<()> {
         try!(self.add_value(variant_index));
         value.serialize(self)
+    }
+
+    fn is_human_readable(&self) -> bool {
+        false
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -457,3 +457,12 @@ fn test_zero_copy_parse() {
         assert_eq!(out, f);
     }
 }
+
+#[test]
+fn not_human_readable() {
+    use std::net::Ipv4Addr;
+    let ip = Ipv4Addr::new(1, 2, 3, 4);
+    the_same(ip);
+    assert_eq!(&ip.octets()[..], &serialize_little(&ip, Infinite).unwrap()[..]);
+    assert_eq!(::std::mem::size_of::<Ipv4Addr>() as u64, serialized_size(&ip));
+}


### PR DESCRIPTION
... by utilizing that bincode is not human readable.

Uses the changes in https://github.com/serde-rs/serde/pull/1044 which
allows data formats to report that they are not human readable. This
lets certain types serialize themselves into a more compact form as they
know that the serialized form does not need to be readable.

Closes #215

BREAKING CHANGE

This changes how types serialize themselves if they detect the
`is_human_readable` state.