### PR TITLE
do not exclude LICENSE.md

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bincode"
 version = "0.9.2"
 authors = ["Ty Overby <ty@pre-alpha.com>", "Francesco Mazzoli <f@mazzo.li>", "David Tolnay <dtolnay@gmail.com>", "Daniel Griffen"]
-exclude = ["logo.png", "tests/*", "examples/*", ".gitignore", ".travis.yml", "changelist.org", "LICENSE.md"]
+exclude = ["logo.png", "tests/*", "examples/*", ".gitignore", ".travis.yml", "changelist.org"]
 
 # renamed `read_types` to `read`
 publish = false


### PR DESCRIPTION
MIT license requires that it is shipped with sources. So crates.io archive should have it as well.