### PR TITLE
bump byteorder version to get transmuting binary float parses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bincode"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["Ty Overby <ty@pre-alpha.com>", "Francesco Mazzoli <f@mazzo.li>", "David Tolnay <dtolnay@gmail.com>", "Daniel Griffen"]
 exclude = ["logo.png", "tests/*", "examples/*", ".gitignore", ".travis.yml", "changelist.org"]
 
@@ -17,7 +17,7 @@ license = "MIT"
 description = "A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!"
 
 [dependencies]
-byteorder = "1.0.0"
+byteorder = "1.2.0"
 serde = "1.0.16"
 
 [dev-dependencies]


### PR DESCRIPTION
this is faster, and produces more accurate (bit-exact) round-tripping.