### PR TITLE
Elide unnecessary copy when consuming a byte buffer.

### DIFF
--- a/src/de/read.rs
+++ b/src/de/read.rs
@@ -124,12 +124,13 @@ where
         let current_length = self.temp_buffer.len();
         if length > current_length {
             self.temp_buffer.reserve_exact(length - current_length);
-            unsafe {
-                self.temp_buffer.set_len(length);
-            }
         }
 
-        self.reader.read_exact(&mut self.temp_buffer[..length])?;
+        unsafe {
+            self.temp_buffer.set_len(length);
+        }
+
+        self.reader.read_exact(&mut self.temp_buffer)?;
         Ok(())
     }
 }
@@ -144,7 +145,7 @@ where
     {
         self.fill_buffer(length)?;
 
-        let string = match ::std::str::from_utf8(&self.temp_buffer[..length]) {
+        let string = match ::std::str::from_utf8(&self.temp_buffer[..]) {
             Ok(s) => s,
             Err(e) => return Err(::ErrorKind::InvalidUtf8Encoding(e).into()),
         };
@@ -155,7 +156,7 @@ where
 
     fn get_byte_buffer(&mut self, length: usize) -> Result<Vec<u8>> {
         self.fill_buffer(length)?;
-        Ok(self.temp_buffer[..length].to_vec())
+        Ok(::std::mem::replace(&mut self.temp_buffer, Vec::new()))
     }
 
     fn forward_read_bytes<V>(&mut self, length: usize, visitor: V) -> Result<V::Value>
@@ -163,7 +164,7 @@ where
         V: serde::de::Visitor<'static>,
     {
         self.fill_buffer(length)?;
-        let r = visitor.visit_bytes(&self.temp_buffer[..length]);
+        let r = visitor.visit_bytes(&self.temp_buffer[..]);
         r
     }
 }


### PR DESCRIPTION
The byte buffer stuff is designed to allow zero copies ... but bincode forces one anyways, to save reallocating its internal `Vec`.