### PR TITLE
Update README example to match #214 changes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ library.
 extern crate serde_derive;
 extern crate bincode;
 
-use bincode::{serialize, deserialize, Infinite};
+use bincode::{serialize, deserialize};
 
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 struct Entity {
@@ -45,7 +45,7 @@ struct World(Vec<Entity>);
 fn main() {
     let world = World(vec![Entity { x: 0.0, y: 4.0 }, Entity { x: 10.0, y: 20.5 }]);
 
-    let encoded: Vec<u8> = serialize(&world, Infinite).unwrap();
+    let encoded: Vec<u8> = serialize(&world).unwrap();
 
     // 8 bytes for the length of the vector, 4 bytes per float.
     assert_eq!(encoded.len(), 8 + 4 * 4);


### PR DESCRIPTION
As shown in `examples/basic.rs`, `bincode::Infinite` isn't used anymore.