### PR TITLE
Add support for 128bit numbers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,12 @@ rust:
     - beta
     - nightly
 
+matrix:
+  include:
+  - rust: 1.18.0
+    script:
+    - cargo test
+
 script:
     - cargo test
     - cargo test --features "i128"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ rust:
     - stable
     - beta
     - nightly
+
+script:
+    - cargo test
+    - cargo test --features "i128"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,11 @@ description = "A binary serialization / deserialization strategy that uses Serde
 
 [dependencies]
 byteorder = "1.2.0"
-serde = "^1.0.27"
+serde = "^1.0.63"
 
 [dev-dependencies]
 serde_bytes = "^0.10.3"
 serde_derive = "^1.0.27"
 
+[features]
+i128 = ["byteorder/i128"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -108,6 +108,31 @@ where
     impl_nums!(f32, deserialize_f32, visit_f32, read_f32);
     impl_nums!(f64, deserialize_f64, visit_f64, read_f64);
 
+    #[cfg(feature = "i128")]
+    impl_nums!(u128, deserialize_u128, visit_u128, read_u128);
+
+    #[cfg(feature = "i128")]
+    impl_nums!(i128, deserialize_i128, visit_i128, read_i128);
+
+    serde_if_integer128! {
+        #[cfg(not(feature = "i128"))]
+        fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: serde::de::Visitor<'de>
+        {
+            let _ = visitor;
+            Err(DeError::custom("u128 is not supported. Enable the `i128` feature of `bincode`"))
+        }
+
+        #[cfg(not(feature = "i128"))]
+        fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
+        where
+            V: serde::de::Visitor<'de>
+        {
+            let _ = visitor;
+            Err(DeError::custom("i128 is not supported. Enable the `i128` feature of `bincode`"))
+        }
+    }
 
     #[inline]
     fn deserialize_u8<V>(self, visitor: V) -> Result<V::Value>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,24 @@
 //!     assert_eq!(target, decoded);
 //! }
 //! ```
+//! 
+//! ### 128bit numbers
+//! 
+//! Support for `i128` and `u128` on Rust toolchains after `1.26.0` is 
+//! enabled through the `i128` feature. Add the following to your 
+//! `Cargo.toml`:
+//! 
+//! ```toml,ignore
+//! [dependencies.bincode]
+//! features = ["i128"]
+//! ```
 
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
 
 extern crate byteorder;
+#[macro_use]
 extern crate serde;
 
 mod config;

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -88,6 +88,34 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         self.writer.write_i64::<O::Endian>(v).map_err(Into::into)
     }
 
+    #[cfg(feature = "i128")]
+    fn serialize_u128(self, v: u128) -> Result<()> {
+        self.writer.write_u128::<O::Endian>(v).map_err(Into::into)
+    }
+
+    #[cfg(feature = "i128")]
+    fn serialize_i128(self, v: i128) -> Result<()> {
+        self.writer.write_i128::<O::Endian>(v).map_err(Into::into)
+    }
+
+    serde_if_integer128! {
+        #[cfg(not(feature = "i128"))]
+        fn serialize_u128(self, v: u128) -> Result<()> {
+            use serde::ser::Error;
+
+            let _ = v;
+            Err(Error::custom("u128 is not supported. Enable the `i128` feature of `bincode`"))
+        }
+
+        #[cfg(not(feature = "i128"))]
+        fn serialize_i128(self, v: i128) -> Result<()> {
+            use serde::ser::Error;
+            
+            let _ = v;
+            Err(Error::custom("i128 is not supported. Enable the `i128` feature of `bincode`"))
+        }
+    }
+
     fn serialize_f32(self, v: f32) -> Result<()> {
         self.writer.write_f32::<O::Endian>(v).map_err(Into::into)
     }
@@ -281,6 +309,16 @@ impl<'a, O: Options> serde::Serializer for &'a mut SizeChecker<O> {
 
     fn serialize_i64(self, v: i64) -> Result<()> {
         self.add_value(v)
+    }
+
+    serde_if_integer128! {
+        fn serialize_u128(self, v: u128) -> Result<()> {
+            self.add_value(v)
+        }
+
+        fn serialize_i128(self, v: i128) -> Result<()> {
+            self.add_value(v)
+        }
     }
 
     fn serialize_f32(self, v: f32) -> Result<()> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -68,6 +68,20 @@ fn test_numbers() {
     the_same(5f64);
 }
 
+#[cfg(feature = "i128")]
+#[test]
+fn test_numbers_128bit() {
+    // unsigned positive
+    the_same(5u128);
+    the_same(u128::max_value());
+    // signed positive
+    the_same(5i128);
+    the_same(i128::max_value());
+    // signed negative
+    the_same(-5i128);
+    the_same(i128::min_value());
+}
+
 #[test]
 fn test_string() {
     the_same("".to_string());


### PR DESCRIPTION
Closes #236 

This PR adds support for encoding/decoding `i128` and `u128` which were stabilized in `rustc` `1.26.0`, and supported as of `serde` `1.0.60`.

There's a new a disabled-by-default `i128` feature flag in `bincode`, which enables support for 128bit numbers. If `bincode` is compiled on a version of Rust that supports 128bit numbers but doesn't have the `i128` feature enabled then we'll return a custom error at runtime suggesting they enable the feature.

If there's anything you'd like changed let me know. Thanks!