### PR TITLE
Introduce `Config::deserialize_seed` for exposing serde's statefull deserialization.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -266,6 +266,12 @@ impl Config {
         config_map!(self, opts => ::internal::deserialize_in_place(reader, opts, place))
     }
 
+    /// Deserializes a slice of bytes with state `seed` using this configuration.
+    #[inline(always)]
+    pub fn deserialize_seed<'a, T: serde::de::DeserializeSeed<'a>>(&self, seed: T, bytes: &'a [u8]) -> Result<T::Value> {
+        config_map!(self, opts => ::internal::deserialize_seed(seed, bytes, opts))
+    }
+
     /// Deserializes an object directly from a `Read`er using this configuration
     ///
     /// If this returns an `Error`, `reader` may be in an invalid state.

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -115,6 +115,17 @@ where
 }
 
 
+pub(crate) fn deserialize_seed<'a, T, O>(seed: T, bytes: &'a [u8], options: O) -> Result<T::Value>
+where
+    T: serde::de::DeserializeSeed<'a>,
+    O: Options,
+{
+    let reader = ::de::read::SliceReader::new(bytes);
+    let options = ::config::WithOtherLimit::new(options, Infinite);
+    let mut deserializer = ::de::Deserializer::new(reader, options);
+    seed.deserialize(&mut deserializer)
+}
+
 pub(crate) trait SizeLimit: Clone {
     /// Tells the SizeLimit that a certain number of bytes has been
     /// read or written.  Returns Err if the limit has been exceeded.


### PR DESCRIPTION
This is needed if one wants to use stateful deserialization, since the `SliceReader` is public but not part of the public API, and `bincode::Deserializer` is private.