### PR TITLE
Make config() inline(always)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,7 @@ pub trait SerializerAcceptor {
 /// | Byte limit | Endianness |
 /// |------------|------------|
 /// | Unlimited  | Little     |
+#[inline(always)]
 pub fn config() -> Config {
     Config::new()
 }


### PR DESCRIPTION
Without this we end up generating code for all configs unless LTO is on.