### PR TITLE
Make i128 support automatic for supporting Rustc versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ documentation = "https://docs.rs/bincode"
 readme = "./readme.md"
 categories = ["network-programming"]
 keywords = ["binary", "encode", "decode", "serialize", "deserialize"]
+build = "build.rs"
 
 license = "MIT"
 description = "A binary serialization / deserialization strategy that uses Serde for transforming structs into bytes and vice versa!"
@@ -23,8 +24,14 @@ serde = "^1.0.63"
 serde_bytes = "^0.10.3"
 serde_derive = "^1.0.27"
 
+[build-dependencies]
+autocfg = "0.1"
+
 [features]
-i128 = ["byteorder/i128"]
+# This feature is no longer used and is DEPRECATED. This crate now
+# automatically enables i128 support for Rust compilers that support it. The
+# feature will be removed if and when a new major version is released.
+i128 = []
 
 [badges]
 travis-ci = { repository = "TyOverby/bincode" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+extern crate autocfg;
+
+fn main() {
+    autocfg::rerun_path(file!());
+
+    let ac = autocfg::new();
+    ac.emit_has_type("i128");
+}

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -108,29 +108,29 @@ where
     impl_nums!(f32, deserialize_f32, visit_f32, read_f32);
     impl_nums!(f64, deserialize_f64, visit_f64, read_f64);
 
-    #[cfg(feature = "i128")]
+    #[cfg(has_i128)]
     impl_nums!(u128, deserialize_u128, visit_u128, read_u128);
 
-    #[cfg(feature = "i128")]
+    #[cfg(has_i128)]
     impl_nums!(i128, deserialize_i128, visit_i128, read_i128);
 
     serde_if_integer128! {
-        #[cfg(not(feature = "i128"))]
+        #[cfg(not(has_i128))]
         fn deserialize_u128<V>(self, visitor: V) -> Result<V::Value>
         where
             V: serde::de::Visitor<'de>
         {
             let _ = visitor;
-            Err(DeError::custom("u128 is not supported. Enable the `i128` feature of `bincode`"))
+            Err(DeError::custom("u128 is not supported. Use Rustc ≥ 1.26."))
         }
 
-        #[cfg(not(feature = "i128"))]
+        #[cfg(not(has_i128))]
         fn deserialize_i128<V>(self, visitor: V) -> Result<V::Value>
         where
             V: serde::de::Visitor<'de>
         {
             let _ = visitor;
-            Err(DeError::custom("i128 is not supported. Enable the `i128` feature of `bincode`"))
+            Err(DeError::custom("i128 is not supported. Use Rustc ≥ 1.26."))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,8 @@
 //!
 //! ### 128bit numbers
 //!
-//! Support for `i128` and `u128` on Rust toolchains after `1.26.0` is
-//! enabled through the `i128` feature. Add the following to your
-//! `Cargo.toml`:
-//!
-//! ```toml,ignore
-//! [dependencies.bincode]
-//! features = ["i128"]
-//! ```
+//! Support for `i128` and `u128` is automatically enabled on Rust toolchains
+//! greater than or equal to `1.26.0`.
 
 #![crate_name = "bincode"]
 #![crate_type = "rlib"]

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -88,31 +88,31 @@ impl<'a, W: Write, O: Options> serde::Serializer for &'a mut Serializer<W, O> {
         self.writer.write_i64::<O::Endian>(v).map_err(Into::into)
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(has_i128)]
     fn serialize_u128(self, v: u128) -> Result<()> {
         self.writer.write_u128::<O::Endian>(v).map_err(Into::into)
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(has_i128)]
     fn serialize_i128(self, v: i128) -> Result<()> {
         self.writer.write_i128::<O::Endian>(v).map_err(Into::into)
     }
 
     serde_if_integer128! {
-        #[cfg(not(feature = "i128"))]
+        #[cfg(not(has_i128))]
         fn serialize_u128(self, v: u128) -> Result<()> {
             use serde::ser::Error;
 
             let _ = v;
-            Err(Error::custom("u128 is not supported. Enable the `i128` feature of `bincode`"))
+            Err(Error::custom("u128 is not supported. Use Rustc ≥ 1.26."))
         }
 
-        #[cfg(not(feature = "i128"))]
+        #[cfg(not(has_i128))]
         fn serialize_i128(self, v: i128) -> Result<()> {
             use serde::ser::Error;
 
             let _ = v;
-            Err(Error::custom("i128 is not supported. Enable the `i128` feature of `bincode`"))
+            Err(Error::custom("i128 is not supported. Use Rustc ≥ 1.26."))
         }
     }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -72,7 +72,7 @@ fn test_numbers() {
     the_same(5f64);
 }
 
-#[cfg(feature = "i128")]
+#[cfg(has_i128)]
 #[test]
 fn test_numbers_128bit() {
     // unsigned positive


### PR DESCRIPTION
Fix #250.

Uses autocfg. If you prefer, I can avoid this as @BurntSushi [did in byteorder](https://github.com/dhardy/byteorder/blob/master/build.rs), but this seems like an apt tool for the job so worth making more popular.

Tested on Rustc 1.22.1, 1.31.1 and a recent nightly.