### PR TITLE
Fix autocfg version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde_bytes = "0.11"
 serde_derive = "1.0.27"
 
 [build-dependencies]
-autocfg = "0.1"
+autocfg = "0.1.2"
 
 [features]
 # This feature is no longer used and is DEPRECATED. This crate now


### PR DESCRIPTION
`autocfg` 0.1.1 does not have `rerun_path`, which causes it to compile errors.